### PR TITLE
Allows reconfiguration of target port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ seeds/
 .env
 .DS_Store
 *.0x/
+
+# Vim persistent undo file
+*.un~

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ If you're interested in understanding how the bot works, I've written [some docu
         - If no observer index is provided, the hand will be logged from the common knowledge perspective.
     - `state <attribute>` will display the internal value of the state's attribute (i.e. `state[attribute]`).
 
+## Targetting local server
+- Export the server hostname 'http://localhost' as `HANABI_HOSTNAME`.
+- If you want to target a port other than 443, export the server port as 'HANABI_PORT'.
+
 ## Supported commands
 Send a PM to the bot on hanab.live (`/pm <HANABI_USERNAME> <message>`) to interact with it.
 - `/join [password]` to join your current lobby. The bot will remain in your table until it is kicked with `/leave`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ If you're interested in understanding how the bot works, I've written [some docu
 
 ## Targetting a local server
 - Export the server hostname 'localhost' as `HANABI_HOSTNAME`.
-- In most cases you will probably run the local server on a port other than 443 (default on hanab.live). To get the bot to connect using a different port, export 'HANABI_PORT'.
+- In most cases you will probably run the local server on a port other than 443 (default on hanab.live). To get the bot to connect using a different port, export `HANABI_PORT`.
+- Unless you have configured local SSL, you should `SSL_ENABLED` to be 'false'.
 
 ## Supported commands
 Send a PM to the bot on hanab.live (`/pm <HANABI_USERNAME> <message>`) to interact with it.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you're interested in understanding how the bot works, I've written [some docu
 ## Targetting a local server
 - Export the server hostname 'localhost' as `HANABI_HOSTNAME`.
 - In most cases you will probably run the local server on a port other than 443 (default on hanab.live). To get the bot to connect using a different port, export `HANABI_PORT`.
-- Unless you have configured local SSL, you should `SSL_ENABLED` to be 'false'.
+- Unless you have configured local SSL, you should export `SSL_ENABLED` to be 'false'.
 
 ## Supported commands
 Send a PM to the bot on hanab.live (`/pm <HANABI_USERNAME> <message>`) to interact with it.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ If you're interested in understanding how the bot works, I've written [some docu
         - If no observer index is provided, the hand will be logged from the common knowledge perspective.
     - `state <attribute>` will display the internal value of the state's attribute (i.e. `state[attribute]`).
 
-## Targetting local server
-- Export the server hostname 'http://localhost' as `HANABI_HOSTNAME`.
-- If you want to target a port other than 443, export the server port as 'HANABI_PORT'.
+## Targetting a local server
+- Export the server hostname 'localhost' as `HANABI_HOSTNAME`.
+- In most cases you will probably run the local server on a port other than 443 (default on hanab.live). To get the bot to connect using a different port, export 'HANABI_PORT'.
 
 ## Supported commands
 Send a PM to the bot on hanab.live (`/pm <HANABI_USERNAME> <message>`) to interact with it.

--- a/src/constants.js
+++ b/src/constants.js
@@ -42,3 +42,4 @@ export const ENDGAME_SOLVING_FUNCS = {
 };
 
 export const HANABI_HOSTNAME = process.env['HANABI_HOSTNAME'] || 'hanab.live';
+export const HANABI_PORT = process.env['HANABI_PORT'] || 443;

--- a/src/constants.js
+++ b/src/constants.js
@@ -42,4 +42,5 @@ export const ENDGAME_SOLVING_FUNCS = {
 };
 
 export const HANABI_HOSTNAME = process.env['HANABI_HOSTNAME'] || 'hanab.live';
-export const HANABI_PORT = process.env['HANABI_PORT'] || 443;
+export const HANABI_PORT = parseInt(process.env['HANABI_PORT']) || 443;
+export const SSL_ENABLED = 443 === HANABI_PORT;

--- a/src/constants.js
+++ b/src/constants.js
@@ -42,8 +42,6 @@ export const ENDGAME_SOLVING_FUNCS = {
 };
 
 export const HANABI_HOSTNAME = process.env['HANABI_HOSTNAME'] || 'hanab.live';
-export const SSL_ENABLED = !process.env['SSL_ENABLED'] 
-                         ? true 
-                         : 'true' === process.env['SSL_ENABLED']
+SSL_ENABLED = undefined === process.env['SSL_ENABLED'] || 'true' === process.env['SSL_ENABLED'];
 export const HANABI_PORT = parseInt(process.env['HANABI_PORT']) || (SSL_ENABLED ? 443 : 80);
 export const CUSTOM_PORT = 443 !== HANABI_PORT && 80 !== HANABI_PORT;

--- a/src/constants.js
+++ b/src/constants.js
@@ -42,5 +42,8 @@ export const ENDGAME_SOLVING_FUNCS = {
 };
 
 export const HANABI_HOSTNAME = process.env['HANABI_HOSTNAME'] || 'hanab.live';
-export const HANABI_PORT = parseInt(process.env['HANABI_PORT']) || 443;
-export const SSL_ENABLED = 443 === HANABI_PORT;
+export const SSL_ENABLED = !process.env['SSL_ENABLED'] 
+                         ? true 
+                         : 'true' === process.env['SSL_ENABLED']
+export const HANABI_PORT = parseInt(process.env['HANABI_PORT']) || (SSL_ENABLED ? 443 : 80);
+export const CUSTOM_PORT = 443 !== HANABI_PORT && 80 !== HANABI_PORT;

--- a/src/constants.js
+++ b/src/constants.js
@@ -42,6 +42,6 @@ export const ENDGAME_SOLVING_FUNCS = {
 };
 
 export const HANABI_HOSTNAME = process.env['HANABI_HOSTNAME'] || 'hanab.live';
-SSL_ENABLED = undefined === process.env['SSL_ENABLED'] || 'true' === process.env['SSL_ENABLED'];
+export const SSL_ENABLED = undefined === process.env['SSL_ENABLED'] || 'true' === process.env['SSL_ENABLED'];
 export const HANABI_PORT = parseInt(process.env['HANABI_PORT']) || (SSL_ENABLED ? 443 : 80);
 export const CUSTOM_PORT = 443 !== HANABI_PORT && 80 !== HANABI_PORT;

--- a/src/hanabi-bot.ts
+++ b/src/hanabi-bot.ts
@@ -71,10 +71,8 @@ async function main() {
 
 	// Establish websocket
 	const protocol = SSL_ENABLED ? 'wss' : 'ws';
-	console.log(HANABI_PORT, CUSTOM_PORT);
 	const port = CUSTOM_PORT ? ':' + HANABI_PORT : '';
 	const wsUrl = `${protocol}://${HANABI_HOSTNAME}${port}/ws`;
-	console.log(wsUrl);
 	const ws = new WebSocket(wsUrl, { headers: { Cookie: cookie } });
 
 	const bot = new Bot(ws, manual !== undefined);

--- a/src/hanabi-bot.ts
+++ b/src/hanabi-bot.ts
@@ -32,7 +32,7 @@ function connect(bot_index = '') {
 
 	return new Promise<string>((resolve, reject) => {
 		// Send login request to hanab.live
-		const protocol = HANABI_PORT === 334 ? https : http;
+		const protocol = SSL_ENABLED ? https : http;
 		const req = protocol.request(options, (res) => {
 			console.log(`Request status code: ${res.statusCode}`);
 

--- a/src/hanabi-bot.ts
+++ b/src/hanabi-bot.ts
@@ -30,7 +30,6 @@ function connect(bot_index = '') {
 		}
 	};
 
-	console.log(options);
 	return new Promise<string>((resolve, reject) => {
 		// Send login request to hanab.live
 		const protocol = SSL_ENABLED ? https : http;

--- a/src/hanabi-bot.ts
+++ b/src/hanabi-bot.ts
@@ -3,7 +3,7 @@ import * as https from 'https';
 import { Bot } from './command-handler.ts';
 import { initConsole } from './tools/console.js';
 import * as Utils from './tools/util.js';
-import { HANABI_HOSTNAME } from './constants.js';
+import { HANABI_HOSTNAME, HANABI_PORT } from './constants.js';
 
 /**
  * Logs in to hanab.live and returns the session cookie to authenticate future requests.
@@ -20,7 +20,7 @@ function connect(bot_index = '') {
 
 	const options = {
 		hostname: HANABI_HOSTNAME,
-		port: 443,
+		port: HANABI_PORT,
 		path: '/login',
 		method: 'POST',
 		headers: {

--- a/src/hanabi-bot.ts
+++ b/src/hanabi-bot.ts
@@ -4,7 +4,7 @@ import * as http from 'http';
 import { Bot } from './command-handler.ts';
 import { initConsole } from './tools/console.js';
 import * as Utils from './tools/util.js';
-import { HANABI_HOSTNAME, HANABI_PORT, SSL_ENABLED } from './constants.js';
+import { CUSTOM_PORT, HANABI_HOSTNAME, HANABI_PORT, SSL_ENABLED } from './constants.js';
 
 /**
  * Logs in to hanab.live and returns the session cookie to authenticate future requests.
@@ -30,6 +30,7 @@ function connect(bot_index = '') {
 		}
 	};
 
+	console.log(options);
 	return new Promise<string>((resolve, reject) => {
 		// Send login request to hanab.live
 		const protocol = SSL_ENABLED ? https : http;
@@ -69,10 +70,11 @@ async function main() {
 	const cookie = await connect(index);
 
 	// Establish websocket
-	const wsUrl = (() => {
-		if (SSL_ENABLED) return `wss://${HANABI_HOSTNAME}/ws`;
-		else return `ws://${HANABI_HOSTNAME}:${HANABI_PORT}/ws`;
-	})();
+	const protocol = SSL_ENABLED ? 'wss' : 'ws';
+	console.log(HANABI_PORT, CUSTOM_PORT);
+	const port = CUSTOM_PORT ? ':' + HANABI_PORT : '';
+	const wsUrl = `${protocol}://${HANABI_HOSTNAME}${port}/ws`;
+	console.log(wsUrl);
 	const ws = new WebSocket(wsUrl, { headers: { Cookie: cookie } });
 
 	const bot = new Bot(ws, manual !== undefined);


### PR DESCRIPTION
Hi

First of all, thank you for creating this bot. It’s so incredibly useful to practice at a lower level since it’s really hard to find people to play at a lower level.

I wanted to practice offline, so I am running the hanab.live server on my machine and wanted the bot to connect to that. What I tried to do, didn’t work somehow. What am I missing here?