### PR TITLE
Implement level 14 support.

### DIFF
--- a/src/basics/Card.js
+++ b/src/basics/Card.js
@@ -178,6 +178,7 @@ export class Card extends ActualCard {
 	hidden = false;
 	permission_to_discard = false;
 	certain_finessed = false;
+	assume_playable = false;
 	maybe_layered = false;
 	trash = false;
 	uncertain = false;

--- a/src/basics/Player.js
+++ b/src/basics/Player.js
@@ -232,6 +232,9 @@ export class Player {
 			if (card.trash && !card.possible.every(p => !state.isBasicTrash(p)))
 				return false;
 
+			if (card.assume_playable && card.possible.some(p => state.isPlayable(p)))
+				return true;
+
 			const unsafe_linked = linked_orders.has(o) &&
 				(state.strikes === 2 ||
 					state.endgameTurns !== -1 ||

--- a/src/basics/hanabi-util.js
+++ b/src/basics/hanabi-util.js
@@ -146,9 +146,10 @@ export function knownAs(game, order, regex) {
  * @param {Game} game
  * @param {number} index
  * @param {number} suitIndex
+ * @param {boolean} [possibly_bluff] If we may be bluffing cards, need to include all suits
  */
-export function getIgnoreOrders(game, index, suitIndex) {
+export function getIgnoreOrders(game, index, suitIndex, possibly_bluff = false) {
 	return (game.next_ignore[index] ?? [])
-		.filter(i => i.inference === undefined || i.inference.suitIndex === suitIndex)
+		.filter(i => i.inference === undefined || possibly_bluff || i.inference.suitIndex === suitIndex)
 		.map(i => i.order);
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,7 @@
 import { find_all_clues as h_find, find_all_discards as h_dc } from './conventions/h-group/take-action.js';
 import { find_all_clues as rs_find, find_all_discards as rs_dc } from './conventions/ref-sieve/take-action.js';
 
-export const MAX_H_LEVEL = 13;
+export const MAX_H_LEVEL = 14;
 export const BOT_VERSION = '1.11.1';
 
 export const ACTION =  /** @type {const} */ ({

--- a/src/conventions/h-group/action-helper.js
+++ b/src/conventions/h-group/action-helper.js
@@ -158,8 +158,10 @@ export function order_trash(game, playerIndex) {
 		return [];
 
 	// The card on chop is the last expected discard with known trash.
+	// It should only be discarded if we have no other known trash or
+	// to save the immediately next player on 0 clues as a scream.
 	const chop = game.players[playerIndex].chop(state.hands[playerIndex]);
-	if (chop !== undefined)
+	if (chop !== undefined && (trash.length === 0 || (trash.length === 1 && state.clue_tokens <= 1)))
 		trash.push(chop);
 	return trash;
 }

--- a/src/conventions/h-group/action-helper.js
+++ b/src/conventions/h-group/action-helper.js
@@ -161,7 +161,7 @@ export function order_trash(game, playerIndex) {
 	// It should only be discarded if we have no other known trash or
 	// to save the immediately next player on 0 clues as a scream.
 	const chop = game.players[playerIndex].chop(state.hands[playerIndex]);
-	if (chop !== undefined && (trash.length === 0 || (trash.length === 1 && state.clue_tokens === 0)))
+	if (chop !== undefined && trash.length === 0)
 		trash.push(chop);
 	return trash;
 }

--- a/src/conventions/h-group/action-helper.js
+++ b/src/conventions/h-group/action-helper.js
@@ -5,7 +5,7 @@ import { unknown_1 } from './hanabi-logic.js';
 import * as Utils from '../../tools/util.js';
 
 import logger from '../../tools/logger.js';
-import { logClue } from '../../tools/log.js';
+import { logCard, logClue } from '../../tools/log.js';
 
 /**
  * @typedef {import('../h-group.js').default} Game
@@ -15,6 +15,7 @@ import { logClue } from '../../tools/log.js';
  * @typedef {import('../../basics/Card.js').ActualCard} ActualCard
  * @typedef {import('../../types.js').ClueResult} ClueResult
  * @typedef {import('../../types.js').Clue} Clue
+ * @typedef {import('../../types.js').Identity} Identity
  * @typedef {import('../../types.js').WaitingConnection} WaitingConnection
  */
 
@@ -116,6 +117,51 @@ export function order_1s(state, player, orders, options = { no_filter: false }) 
 
 		return 1;
 	});
+}
+
+/**
+ * Returns the trash cards in the order that they should be discarded.
+ * @param {Game} game
+ * @param {number} playerIndex
+ */
+export function order_trash(game, playerIndex) {
+	const { state, common } = game;
+
+	/** @type {(identity: Identity, order: number) => boolean} */
+	const visible_self = (identity, order) =>
+		state.hands[playerIndex].some(o => {
+			const card = common.thoughts[o];
+
+			return card.matches(identity, { infer: true }) &&
+				state.deck[o].matches(identity, { assume: true }) &&
+				(state.deck[o].clued || (card.blind_playing && !card.uncertain)) &&
+				o !== order &&
+				!common.links.some(link => link.orders.includes(order));
+		});
+
+
+	const trash = state.hands[playerIndex].filter(o => {
+		if (common.thoughts[o].trash)
+			return true;
+
+		const poss = common.thoughts[o].uncertain ? common.thoughts[o].possible : common.thoughts[o].possibilities;
+
+		// Every possibility is trash or duplicated in our hand
+		const trash = poss.every(p => state.isBasicTrash(p) || visible_self(p, o));
+
+		if (trash)
+			logger.debug(`order ${o} is known trash, poss ${poss.map(logCard).join()}, ${poss.map(p => state.isBasicTrash(p)).join()}`);
+
+		return trash;
+	});
+	if (trash.length === 0)
+		return [];
+
+	// The card on chop is the last expected discard with known trash.
+	const chop = game.players[playerIndex].chop(state.hands[playerIndex]);
+	if (chop !== undefined)
+		trash.push(chop);
+	return trash;
 }
 
 /**

--- a/src/conventions/h-group/action-helper.js
+++ b/src/conventions/h-group/action-helper.js
@@ -161,7 +161,7 @@ export function order_trash(game, playerIndex) {
 	// It should only be discarded if we have no other known trash or
 	// to save the immediately next player on 0 clues as a scream.
 	const chop = game.players[playerIndex].chop(state.hands[playerIndex]);
-	if (chop !== undefined && (trash.length === 0 || (trash.length === 1 && state.clue_tokens <= 1)))
+	if (chop !== undefined && (trash.length === 0 || (trash.length === 1 && state.clue_tokens === 0)))
 		trash.push(chop);
 	return trash;
 }

--- a/src/conventions/h-group/clue-finder/clue-finder.js
+++ b/src/conventions/h-group/clue-finder/clue-finder.js
@@ -291,6 +291,11 @@ export function get_clue_interp(game, clue, giver, options) {
 				return;
 			}
 
+			if (chop_moved.length > 0 && !chop_moved.some(o => !state.isBasicTrash(state.deck[o]))) {
+				logger.warn('did not chop move any valuable cards');
+				return;
+			}
+
 			if (playables.length === 0) {
 				logger.warn('play clue with no playables!');
 				new_interp = new_touched.length > 0 || elim > 0 ? CLUE_INTERP.STALL_FILLIN : CLUE_INTERP.STALL_BURN;

--- a/src/conventions/h-group/clue-finder/clue-finder.js
+++ b/src/conventions/h-group/clue-finder/clue-finder.js
@@ -163,7 +163,7 @@ export function get_clue_interp(game, clue, giver, options) {
 	const giver_player = game.players[giver];
 
 	const list = state.clueTouched(hand, clue);
-	const { focus, chop } = determine_focus(game, hand, common, list, clue);
+	const { focus, chop } = determine_focus(game, hand, common, list, giver, target, clue);
 	const focused_card = state.deck[focus];
 
 	const in_finesse = common.waiting_connections.find(w_conn => {

--- a/src/conventions/h-group/clue-finder/determine-clue.js
+++ b/src/conventions/h-group/clue-finder/determine-clue.js
@@ -193,7 +193,7 @@ export function get_result(game, hypo_game, action, provisions = {}) {
 	const hand = state.hands[target];
 
 	const list = provisions.list ?? state.clueTouched(hand, clue);
-	const { focus } = determine_focus(game, hand, common, list, clue);
+	const { focus } = determine_focus(game, hand, common, list, giver, target, clue);
 
 	const { new_touched, fill } = elim_result(hypo_state, common, hypo_common, hand, list);
 	const { bad_touch, cm_dupe, trash, avoidable_dupe } = bad_touch_result(game, hypo_game, hypo_common, giver, target);

--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -183,7 +183,7 @@ export function find_known_connecting(game, giver, identity, ignoreOrders = [], 
  * @param {Identity} identity
  * @param {number[]} [connected] 	The orders of cards that have previously connected (and should be skipped).
  * @param {number[]} [ignoreOrders] The orders of cards to ignore when searching.
- * @param {{assumeTruth?: boolean, noLayer?: boolean, bluffed?: boolean}} options
+ * @param {{assumeTruth?: boolean, noLayer?: boolean, bluffed?: boolean }} options
  * @returns {Connection | undefined}
  */
 function find_unknown_connecting(game, action, reacting, identity, connected = [], ignoreOrders = [], options = {}) {
@@ -336,7 +336,7 @@ function find_unknown_connecting(game, action, reacting, identity, connected = [
  * @param {Set<number>} thinks_stall Whether the clue appears to be a stall to these players.
  * @param {number[]} [connected]	The orders of cards that have previously connected (and should be skipped).
  * @param {number[]} [ignoreOrders] The orders of cards to ignore when searching.
- * @param {{knownOnly?: number[], assumeTruth?: boolean, bluffed?: boolean}} options
+ * @param {{knownOnly?: number[], assumeTruth?: boolean, bluffed?: boolean, immediate?: boolean, playerOrder?: number[]}} options
  * @returns {Connection[]}
  */
 export function find_connecting(game, action, identity, looksDirect, thinks_stall, connected = [], ignoreOrders = [], options = {}) {
@@ -394,7 +394,7 @@ export function find_connecting(game, action, identity, looksDirect, thinks_stal
 	const wrong_prompts = [];
 	const old_play_stacks = state.play_stacks;
 
-	const conn_player_order = [target, ...Utils.range(0, state.numPlayers).map(i => (state.numPlayers + giver - i - 1) % state.numPlayers).filter(i => i !== target), target];
+	const conn_player_order = options.playerOrder || [target, ...Utils.range(0, state.numPlayers).map(i => (state.numPlayers + giver - i - 1) % state.numPlayers).filter(i => i !== target), target];
 
 	// Only consider prompts/finesses if no connecting cards found
 	for (let i = 0; i < conn_player_order.length; i++) {
@@ -420,6 +420,10 @@ export function find_connecting(game, action, identity, looksDirect, thinks_stal
 			wrong_prompts.push(connecting);
 			continue;
 		}
+
+		// If we need an immediate play, the connection cannot be hidden.
+		if (connecting?.hidden && options.immediate)
+			continue;
 
 		// If the connection is hidden, that player must have the actual card playable in order for the layer to work.
 		// Thus, we keep searching for unknown connections in their hand until we find a non-hidden connection.
@@ -458,7 +462,7 @@ export function find_connecting(game, action, identity, looksDirect, thinks_stal
 	state.play_stacks = old_play_stacks;
 
 	// Unknown playable(s) in our hand (obviously, we can't use them in our clues)
-	if (giver !== state.ourPlayerIndex && !options.knownOnly?.includes(state.ourPlayerIndex)) {
+	if (giver !== state.ourPlayerIndex && !options.knownOnly?.includes(state.ourPlayerIndex) && (!options.playerOrder || options.playerOrder.includes(state.ourPlayerIndex))) {
 		let layered = false;
 		/** @type {number[]} */
 		const playable_conns = [];

--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -421,8 +421,8 @@ export function find_connecting(game, action, identity, looksDirect, thinks_stal
 			continue;
 		}
 
-		// If we need an immediate play, the connection cannot be hidden.
-		if (connecting?.hidden && options.immediate)
+		// If we need an immediate play, the connection cannot be hidden or behind other finesses.
+		if (options.immediate && (state.hands[playerIndex].some(o => common.thoughts[o].blind_playing) || connecting?.hidden))
 			continue;
 
 		// If the connection is hidden, that player must have the actual card playable in order for the layer to work.

--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -26,7 +26,7 @@ import { visibleFind } from '../../../basics/hanabi-util.js';
  * @param {number} giver 		The player index that gave the clue. They cannot deduce unknown information about their own hand.
  * @param {Identity} identity
  * @param {number[]} [ignoreOrders]		The orders of cards to ignore when searching.
- * @param {{knownOnly?: number[]}} options
+ * @param {{knownOnly?: number[], playerOrder?: number[]}} options
  * @returns {Connection | undefined}
  */
 export function find_known_connecting(game, giver, identity, ignoreOrders = [], options = {}) {
@@ -42,9 +42,8 @@ export function find_known_connecting(game, giver, identity, ignoreOrders = [], 
 	});
 
 	// Globally known
-	for (let i = 0; i < state.numPlayers; i++) {
-		const playerIndex = (giver + i) % state.numPlayers;
-
+	const known_play_order = options.playerOrder ?? Utils.range(0, state.numPlayers).map(i => (state.numPlayers + giver + i) % state.numPlayers);
+	for (const playerIndex of known_play_order) {
 		const globally_known = state.hands[playerIndex].find(order => {
 			const ineligible = ignoreOrders.includes(order) ||
 				!common.thoughts[order].touched ||
@@ -107,8 +106,8 @@ export function find_known_connecting(game, giver, identity, ignoreOrders = [], 
 	}
 
 	// Visible and already going to be played (excluding giver)
-	for (let i = 1; i < state.numPlayers; i++) {
-		const playerIndex = (giver + i) % state.numPlayers;
+	const visible_play_order = (options.playerOrder ?? Utils.range(1, state.numPlayers).map(i => (state.numPlayers + giver + i) % state.numPlayers)).filter(p => p != giver);
+	for (const playerIndex of visible_play_order) {
 
 		if (options.knownOnly?.includes(playerIndex))
 			continue;
@@ -171,7 +170,7 @@ export function find_known_connecting(game, giver, identity, ignoreOrders = [], 
 		}
 	});
 
-	if (giver_asymmetric !== undefined)
+	if ((options.playerOrder === undefined || options.playerOrder.includes(giver)) && giver_asymmetric !== undefined)
 		return { type: 'known', reacting: giver, order: giver_asymmetric, identities: [identity] };
 }
 
@@ -394,7 +393,7 @@ export function find_connecting(game, action, identity, looksDirect, thinks_stal
 	const wrong_prompts = [];
 	const old_play_stacks = state.play_stacks;
 
-	const conn_player_order = options.playerOrder || [target, ...Utils.range(0, state.numPlayers).map(i => (state.numPlayers + giver - i - 1) % state.numPlayers).filter(i => i !== target), target];
+	const conn_player_order = options.playerOrder ?? [target, ...Utils.range(0, state.numPlayers).map(i => (state.numPlayers + giver - i - 1) % state.numPlayers).filter(i => i !== target), target];
 
 	// Only consider prompts/finesses if no connecting cards found
 	for (let i = 0; i < conn_player_order.length; i++) {
@@ -413,7 +412,7 @@ export function find_connecting(game, action, identity, looksDirect, thinks_stal
 		const already_connected = connected.slice();
 		state.play_stacks = old_play_stacks.slice();
 
-		const unk_options = { assumeTruth: options.assumeTruth, noLayer: i === 0, bluffed: options.bluffed };
+		const unk_options = { assumeTruth: options.assumeTruth, noLayer: options.playerOrder !== undefined || i === 0, bluffed: options.bluffed };
 		let connecting = find_unknown_connecting(game, action, playerIndex, identity, already_connected, ignoreOrders, unk_options);
 
 		if (connecting?.type === 'terminate') {
@@ -462,7 +461,7 @@ export function find_connecting(game, action, identity, looksDirect, thinks_stal
 	state.play_stacks = old_play_stacks;
 
 	// Unknown playable(s) in our hand (obviously, we can't use them in our clues)
-	if (giver !== state.ourPlayerIndex && !options.knownOnly?.includes(state.ourPlayerIndex) && (!options.playerOrder || options.playerOrder.includes(state.ourPlayerIndex))) {
+	if (giver !== state.ourPlayerIndex && !options.knownOnly?.includes(state.ourPlayerIndex) && (options.playerOrder === undefined || options.playerOrder.includes(state.ourPlayerIndex))) {
 		let layered = false;
 		/** @type {number[]} */
 		const playable_conns = [];

--- a/src/conventions/h-group/clue-interpretation/connecting-cards.js
+++ b/src/conventions/h-group/clue-interpretation/connecting-cards.js
@@ -106,7 +106,7 @@ export function find_known_connecting(game, giver, identity, ignoreOrders = [], 
 	}
 
 	// Visible and already going to be played (excluding giver)
-	const visible_play_order = (options.playerOrder ?? Utils.range(1, state.numPlayers).map(i => (state.numPlayers + giver + i) % state.numPlayers)).filter(p => p != giver);
+	const visible_play_order = (options.playerOrder ?? Utils.range(1, state.numPlayers).map(i => (giver + i) % state.numPlayers));
 	for (const playerIndex of visible_play_order) {
 
 		if (options.knownOnly?.includes(playerIndex))
@@ -144,7 +144,7 @@ export function find_known_connecting(game, giver, identity, ignoreOrders = [], 
 		}
 	}
 
-	const giver_asymmetric = state.hands[giver].find(o => {
+	const giver_asymmetric = (options.playerOrder === undefined || options.playerOrder.includes(giver)) ? state.hands[giver].find(o => {
 		if (ignoreOrders.includes(o) || !state.deck[o].matches(identity))
 			return false;
 
@@ -168,9 +168,9 @@ export function find_known_connecting(game, giver, identity, ignoreOrders = [], 
 			logger.highlight('cyan', `connecting using giver's asymmetric knowledge of ${logCard(identity)}! we could have missing ${logCard(missing_ids[0])}`);
 			return true;
 		}
-	});
+	}) : undefined;
 
-	if ((options.playerOrder === undefined || options.playerOrder.includes(giver)) && giver_asymmetric !== undefined)
+	if (giver_asymmetric !== undefined)
 		return { type: 'known', reacting: giver, order: giver_asymmetric, identities: [identity] };
 }
 

--- a/src/conventions/h-group/clue-interpretation/connection-helper.js
+++ b/src/conventions/h-group/clue-interpretation/connection-helper.js
@@ -1,7 +1,7 @@
 import { CLUE } from '../../../constants.js';
 import { CARD_STATUS } from '../../../basics/Card.js';
 import { IdentitySet } from '../../../basics/IdentitySet.js';
-import { IllegalInterpretation, find_own_finesses } from './own-finesses.js';
+import { IllegalInterpretation, find_own_finesses, find_own_trash_finesses } from './own-finesses.js';
 
 import logger from '../../../tools/logger.js';
 import { logCard, logConnection, logConnections } from '../../../tools/log.js';
@@ -214,7 +214,7 @@ export function find_symmetric_connections(game, action, focusResult, inf_possib
 			// Fake connection - we need to blind play too many times
 			const fake = blind_plays(connections, state.ourPlayerIndex) > ownBlindPlays;
 
-			if (connections.find(conn => conn.type !== 'known' && conn.type !== 'playable')?.reacting === target)
+			if (connections.length === 0 || connections.find(conn => conn.type !== 'known' && conn.type !== 'playable')?.reacting === target)
 				self_connections.push({ ...id.raw(), connections, fake });
 			else
 				non_self_connections.push({ ...id.raw(), connections, fake });

--- a/src/conventions/h-group/clue-interpretation/connection-helper.js
+++ b/src/conventions/h-group/clue-interpretation/connection-helper.js
@@ -147,14 +147,12 @@ export function find_trash_finesses(game, action, focus, connections, suitIndex)
 		return [];
 
 	logger.info('found possible trash finesse:', logConnections(tf_connections, possible_trash));
-	return possible_trash.map(id => {
-		return {
-			...id,
-			save: false,
-			connections: tf_connections,
-			interp: CLUE_INTERP.TRASH_FINESSE
-		};
-	});
+	return possible_trash.map(id => ({
+		...id,
+		save: false,
+		connections: tf_connections,
+		interp: CLUE_INTERP.TRASH_FINESSE
+	}));
 }
 
 /**
@@ -297,7 +295,7 @@ export function find_symmetric_connections(game, action, focusResult, inf_possib
 			// Fake connection - we need to blind play too many times
 			const fake = blind_plays(connections, state.ourPlayerIndex) > ownBlindPlays;
 
-			if (connections.length === 0 || connections.find(conn => conn.type !== 'known' && conn.type !== 'playable')?.reacting === target)
+			if (connections.find(conn => conn.type !== 'known' && conn.type !== 'playable')?.reacting === target)
 				self_connections.push({ ...id.raw(), connections, fake });
 			else
 				non_self_connections.push({ ...id.raw(), connections, fake });

--- a/src/conventions/h-group/clue-interpretation/connection-helper.js
+++ b/src/conventions/h-group/clue-interpretation/connection-helper.js
@@ -1,7 +1,7 @@
 import { CLUE } from '../../../constants.js';
 import { CARD_STATUS } from '../../../basics/Card.js';
 import { IdentitySet } from '../../../basics/IdentitySet.js';
-import { IllegalInterpretation, find_own_finesses, find_own_trash_finesses } from './own-finesses.js';
+import { IllegalInterpretation, find_own_finesses } from './own-finesses.js';
 
 import logger from '../../../tools/logger.js';
 import { logCard, logConnection, logConnections } from '../../../tools/log.js';

--- a/src/conventions/h-group/clue-interpretation/connection-helper.js
+++ b/src/conventions/h-group/clue-interpretation/connection-helper.js
@@ -98,13 +98,12 @@ export function is_trash_finesse_target(game, focus) {
  * @param {ClueAction} action
  * @param {number} focus
  * @param {Connection[]} connections
- * @param {Identity} promised
+ * @param {number} suitIndex
  * @returns {FocusPossibility[]}
  */
-export function find_trash_finesses(game, action, focus, connections, promised) {
+export function find_trash_finesses(game, action, focus, connections, suitIndex) {
 	const { state, common } = game;
 	const focus_thoughts = common.thoughts[focus];
-	const { suitIndex } = promised;
 
 	if (game.level < LEVEL.TRASH_MOVES || !is_trash_finesse_target(game, focus) ||
 		!connections.some(conn => conn.type === 'finesse' && !conn.hidden))
@@ -119,7 +118,7 @@ export function find_trash_finesses(game, action, focus, connections, promised) 
 		if (id.suitIndex === suitIndex && id.rank > ourMaxRank)
 			ourMaxRank = id.rank;
 	}
-	while (ci < connections.length && connections[ci].reacting) {
+	while (ci < connections.length) {
 		if (!inBetween(state.numPlayers, connections[ci].reacting, lastPlayer, action.target))
 			break;
 		// We can't rely on this player playing a new card if they're already blind playing

--- a/src/conventions/h-group/clue-interpretation/connection-helper.js
+++ b/src/conventions/h-group/clue-interpretation/connection-helper.js
@@ -6,13 +6,15 @@ import { IllegalInterpretation, find_own_finesses } from './own-finesses.js';
 import logger from '../../../tools/logger.js';
 import { logCard, logConnection, logConnections } from '../../../tools/log.js';
 import { isTrash } from '../../../basics/hanabi-util.js';
-import { FOCUS_INTERP, LEVEL } from '../h-constants.js';
+import { CLUE_INTERP, FOCUS_INTERP, LEVEL } from '../h-constants.js';
 import { variantRegexes } from '../../../variants.js';
 import { colour_save, find_trash_push, rank_save } from './focus-possible.js';
+import { inBetween } from '../hanabi-logic.js';
 
 /**
  * @typedef {import('../../h-group.js').default} Game
  * @typedef {import('../../../basics/State.js').State} State
+ * @typedef {import('../../../basics/Player.js').BasicCard} BasicCard
  * @typedef {import('../../../basics/Card.js').ActualCard} ActualCard
  * @typedef {import('../../h-player.js').HGroup_Player} Player
  * @typedef {import('../../../basics/Action.ts').ClueAction} ClueAction
@@ -88,6 +90,69 @@ export function is_trash_finesse_target(game, focus) {
 	const playable_count = playable_ids.map(id => state.cardCount(id) - state.discard_stacks[id.suitIndex][id.rank - 1]).reduce((a, b) => a + b, 0);
 	return game.level >= LEVEL.TRASH_MOVES &&
 		playable_count > 1;
+}
+
+/**
+ * Returns a list of possible trash finesse connections.
+ * @param {Game} game
+ * @param {ClueAction} action
+ * @param {number} focus
+ * @param {Connection[]} connections
+ * @param {Identity} promised
+ * @returns {FocusPossibility[]}
+ */
+export function find_trash_finesses(game, action, focus, connections, promised) {
+	const { state, common } = game;
+	const focus_thoughts = common.thoughts[focus];
+	const { suitIndex } = promised;
+
+	if (game.level < LEVEL.TRASH_MOVES || !is_trash_finesse_target(game, focus) ||
+		!connections.some(conn => conn.type === 'finesse' && !conn.hidden))
+		return [];
+
+	// In order to recognize a colour trash finesse, either
+	// 1. The connecting plays before the target don't connect to the target, or
+	let lastPlayer = action.giver;
+	let ci = 0;
+	let ourMaxRank = 0;
+	for (const id of focus_thoughts.possible) {
+		if (id.suitIndex === suitIndex && id.rank > ourMaxRank)
+			ourMaxRank = id.rank;
+	}
+	while (ci < connections.length && connections[ci].reacting) {
+		if (!inBetween(state.numPlayers, connections[ci].reacting, lastPlayer, action.target))
+			break;
+		lastPlayer = connections[ci].reacting;
+		ci++;
+	}
+	const no_connecting_play = ci > 0 && connections[ci-1].identities.every(id => id.suitIndex !== suitIndex || id.rank >= ourMaxRank);
+
+	// Can only reverse trash finesse before end game.
+	const connected_reverse_finesses = state.inEndgame() ? [] : connections.filter((conn, conn_i) => conn_i >= ci && conn.type === 'finesse');
+	const possible_trash = focus_thoughts.possible.filter(id =>
+		state.isBasicTrash(id) ||
+		connected_reverse_finesses.some(cf => cf.identities.some(cid => cid.suitIndex === id.suitIndex && cid.rank === id.rank)));
+	const tf_connections = connections.slice();
+	// The connection is only a bluff if we didn't find the expected rank playable.
+	tf_connections[0].possibly_bluff = tf_connections[0].bluff;
+
+	// 2. The target knows their card must either be trash or match a reverse finesse play.
+	const card_matches_last_play = focus_thoughts.possible.every(id =>
+		possible_trash.includes(id)
+	);
+
+	if (!no_connecting_play && !card_matches_last_play)
+		return [];
+
+	logger.info('found possible trash finesse:', logConnections(tf_connections, possible_trash));
+	return possible_trash.map(id => {
+		return {
+			...id,
+			save: false,
+			connections: tf_connections,
+			interp: CLUE_INTERP.TRASH_FINESSE
+		};
+	});
 }
 
 /**

--- a/src/conventions/h-group/clue-interpretation/connection-helper.js
+++ b/src/conventions/h-group/clue-interpretation/connection-helper.js
@@ -6,9 +6,10 @@ import { IllegalInterpretation, find_own_finesses } from './own-finesses.js';
 import logger from '../../../tools/logger.js';
 import { logCard, logConnection, logConnections } from '../../../tools/log.js';
 import { isTrash } from '../../../basics/hanabi-util.js';
-import { LEVEL } from '../h-constants.js';
+import { FOCUS_INTERP, LEVEL } from '../h-constants.js';
 import { variantRegexes } from '../../../variants.js';
-import { colour_save, rank_save } from './focus-possible.js';
+import { colour_save, find_trash_push, rank_save } from './focus-possible.js';
+import { interpret_tp } from '../hanabi-logic.js';
 
 /**
  * @typedef {import('../../h-group.js').default} Game
@@ -173,6 +174,9 @@ export function find_symmetric_connections(game, action, focusResult, inf_possib
 
 	/** @type {(conns: Connection[], playerIndex: number) => number} */
 	const blind_plays = (conns, playerIndex) => conns.filter(conn => conn.type === 'finesse' && conn.reacting === playerIndex).length;
+
+	if (focusResult.focus_interp === FOCUS_INTERP.TRASH_PUSH)
+		return find_trash_push(game, action, focusResult, new Set());
 
 	for (const id of focused_card.inferred) {
 		// Receiver won't consider trash possibilities or ones that are subsumed by real possibilities

--- a/src/conventions/h-group/clue-interpretation/connection-helper.js
+++ b/src/conventions/h-group/clue-interpretation/connection-helper.js
@@ -83,10 +83,10 @@ export function valid_bluff(game, action, blind, truth, reacting, connected, sym
  * @param {ClueAction} action
  * @param {number} focus
  * @param {Connection[]} connections
- * @param {number} suitIndex
+ * @param {Identity} identity
  * @returns {FocusPossibility[]}
  */
-export function find_trash_finesses(game, action, focus, connections, suitIndex) {
+export function find_trash_finesses(game, action, focus, connections, identity) {
 	const { giver, clue, target } = action;
 	const { state, common } = game;
 	const focus_thoughts = common.thoughts[focus];
@@ -101,7 +101,7 @@ export function find_trash_finesses(game, action, focus, connections, suitIndex)
 	let ci = 0;
 	let ourMaxRank = 0;
 	for (const id of focus_thoughts.possible) {
-		if (id.suitIndex === suitIndex && id.rank > ourMaxRank)
+		if (id.suitIndex === identity.suitIndex && id.rank > ourMaxRank)
 			ourMaxRank = id.rank;
 	}
 	while (ci < connections.length) {
@@ -113,7 +113,18 @@ export function find_trash_finesses(game, action, focus, connections, suitIndex)
 		lastPlayer = connections[ci].reacting;
 		ci++;
 	}
-	const no_connecting_play = ci > 0 && connections[ci-1].identities.every(id => id.suitIndex !== suitIndex || id.rank >= ourMaxRank);
+	// If there are plays before the target, check if the play would prove it trash.
+	let playables_remaining = focus_thoughts.possible.filter(id => !state.isBasicTrash(id));
+	if (ci > 0) {
+		if (connections[0].bluff) {
+			// If we have a bluff connection, we can only eliminate immediate playables or connecting matching ranks.
+			playables_remaining = playables_remaining.filter(id => !state.isPlayable(id) && !connections[ci-1].identities.every(cid => cid.suitIndex === id.suitIndex && cid.rank >= id.rank));
+		} else {
+			// Otherwise, we can rule out anything that doesn't follow the connection.
+			playables_remaining = playables_remaining.filter(id => !connections[ci-1].identities.every(cid => cid.suitIndex !== id.suitIndex || cid.rank >= id.rank));
+		}
+	}
+	const no_connecting_play = playables_remaining.length === 0;
 
 	// Can only reverse trash finesse before end game.
 	const connected_reverse_finesses = state.inEndgame() ? [] : connections.filter((conn, conn_i) => conn_i >= ci && conn.type === 'finesse');
@@ -124,12 +135,17 @@ export function find_trash_finesses(game, action, focus, connections, suitIndex)
 	// The connection is only a bluff if we didn't find the expected rank playable.
 	tf_connections[0].possibly_bluff = tf_connections[0].bluff;
 
-	// 2. The target knows their card must either be trash or match a reverse finesse play.
+	// 2. The target knows their card must either be trash or match a reverse finesse play, or
 	const card_matches_last_play = focus_thoughts.possible.every(id =>
 		possible_trash.includes(id)
 	);
 
-	if (!no_connecting_play && !card_matches_last_play)
+	// 3. There is only one playable card and we might have it in our hand.
+	const playable_ids = focus_thoughts.inferred.filter(id => !possible_trash.includes(id) && !connections.some(conn => conn.identities.length == 1 && conn.identities[0].rank == id.rank && conn.identities[0].suitIndex == id.suitIndex));
+	const cardCount = playable_ids.map(id => state.cardCount(id) - state.discard_stacks[id.suitIndex][id.rank - 1]).reduce((a, b) => a + b, 0);
+	const maybeInOurHand = cardCount === 1 && giver != state.ourPlayerIndex && target !== state.ourPlayerIndex && state.ourHand.some(o => game.me.thoughts[o].possible.has(playable_ids[0]));
+
+	if (!no_connecting_play && !card_matches_last_play && !maybeInOurHand)
 		return [];
 
 	logger.info('found possible trash finesse:', logConnections(tf_connections, possible_trash));

--- a/src/conventions/h-group/clue-interpretation/connection-helper.js
+++ b/src/conventions/h-group/clue-interpretation/connection-helper.js
@@ -92,7 +92,7 @@ export function find_trash_finesses(game, action, focus, connections, identity) 
 	const focus_thoughts = common.thoughts[focus];
 
 	if (game.level < LEVEL.TRASH_MOVES || is_trash_clue(game, giver, clue, target, focus, common) ||
-		!connections.some(conn => conn.type === 'finesse' && !conn.hidden))
+		!connections.some(conn => conn.type === 'finesse'))
 		return [];
 
 	// The first unknown play come from another player.

--- a/src/conventions/h-group/clue-interpretation/connection-helper.js
+++ b/src/conventions/h-group/clue-interpretation/connection-helper.js
@@ -10,6 +10,7 @@ import { CLUE_INTERP, FOCUS_INTERP, LEVEL } from '../h-constants.js';
 import { variantRegexes } from '../../../variants.js';
 import { colour_save, find_trash_push, rank_save } from './focus-possible.js';
 import { inBetween } from '../hanabi-logic.js';
+import { is_trash_clue } from './interpret-cm.js';
 
 /**
  * @typedef {import('../../h-group.js').default} Game
@@ -77,22 +78,6 @@ export function valid_bluff(game, action, blind, truth, reacting, connected, sym
 }
 
 /**
- * Returns whether the given identity is a valid playable identity for a trash finesse.
- * @param {Game} game
- * @param {number} focus
- */
-export function is_trash_finesse_target(game, focus) {
-	const { state } = game;
-	// If there is only one missing promised card, the receiver would be
-	// able to tell if it is trash by that single card being in our hand.
-	// Only allow trash finesses with other possible identities.
-	const playable_ids = game.common.thoughts[focus].possible.filter(id => !state.isBasicTrash(id));
-	const playable_count = playable_ids.map(id => state.cardCount(id) - state.discard_stacks[id.suitIndex][id.rank - 1]).reduce((a, b) => a + b, 0);
-	return game.level >= LEVEL.TRASH_MOVES &&
-		playable_count > 1;
-}
-
-/**
  * Returns a list of possible trash finesse connections.
  * @param {Game} game
  * @param {ClueAction} action
@@ -102,10 +87,11 @@ export function is_trash_finesse_target(game, focus) {
  * @returns {FocusPossibility[]}
  */
 export function find_trash_finesses(game, action, focus, connections, suitIndex) {
+	const { giver, clue, target } = action;
 	const { state, common } = game;
 	const focus_thoughts = common.thoughts[focus];
 
-	if (game.level < LEVEL.TRASH_MOVES || !is_trash_finesse_target(game, focus) ||
+	if (game.level < LEVEL.TRASH_MOVES || is_trash_clue(game, giver, clue, target, focus, common) ||
 		!connections.some(conn => conn.type === 'finesse' && !conn.hidden))
 		return [];
 

--- a/src/conventions/h-group/clue-interpretation/connection-helper.js
+++ b/src/conventions/h-group/clue-interpretation/connection-helper.js
@@ -9,7 +9,6 @@ import { isTrash } from '../../../basics/hanabi-util.js';
 import { FOCUS_INTERP, LEVEL } from '../h-constants.js';
 import { variantRegexes } from '../../../variants.js';
 import { colour_save, find_trash_push, rank_save } from './focus-possible.js';
-import { interpret_tp } from '../hanabi-logic.js';
 
 /**
  * @typedef {import('../../h-group.js').default} Game

--- a/src/conventions/h-group/clue-interpretation/connection-helper.js
+++ b/src/conventions/h-group/clue-interpretation/connection-helper.js
@@ -95,6 +95,10 @@ export function find_trash_finesses(game, action, focus, connections, identity) 
 		!connections.some(conn => conn.type === 'finesse' && !conn.hidden))
 		return [];
 
+	// The first unknown play come from another player.
+	if (connections.find(conn => conn.type === 'finesse' || conn.type === 'prompt').reacting === target)
+		return [];
+
 	// In order to recognize a colour trash finesse, either
 	// 1. The connecting plays before the target don't connect to the target, or
 	let lastPlayer = action.giver;

--- a/src/conventions/h-group/clue-interpretation/connection-helper.js
+++ b/src/conventions/h-group/clue-interpretation/connection-helper.js
@@ -75,6 +75,22 @@ export function valid_bluff(game, action, blind, truth, reacting, connected, sym
 }
 
 /**
+ * Returns whether the given identity is a valid playable identity for a trash finesse.
+ * @param {Game} game
+ * @param {number} focus
+ */
+export function is_trash_finesse_target(game, focus) {
+	const { state } = game;
+	// If there is only one missing promised card, the receiver would be
+	// able to tell if it is trash by that single card being in our hand.
+	// Only allow trash finesses with other possible identities.
+	const playable_ids = game.common.thoughts[focus].possible.filter(id => !state.isBasicTrash(id));
+	const playable_count = playable_ids.map(id => state.cardCount(id) - state.discard_stacks[id.suitIndex][id.rank - 1]).reduce((a, b) => a + b, 0);
+	return game.level >= LEVEL.TRASH_MOVES &&
+		playable_count > 1;
+}
+
+/**
  * Returns whether the given identity is a valid target for an intermediate bluff.
  * @param {Game} game
  * @param {ClueAction} action

--- a/src/conventions/h-group/clue-interpretation/connection-helper.js
+++ b/src/conventions/h-group/clue-interpretation/connection-helper.js
@@ -122,6 +122,9 @@ export function find_trash_finesses(game, action, focus, connections, promised) 
 	while (ci < connections.length && connections[ci].reacting) {
 		if (!inBetween(state.numPlayers, connections[ci].reacting, lastPlayer, action.target))
 			break;
+		// We can't rely on this player playing a new card if they're already blind playing
+		if (state.hands[connections[ci].reacting].some(o => common.thoughts[o].blind_playing))
+			break;
 		lastPlayer = connections[ci].reacting;
 		ci++;
 	}

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -124,7 +124,8 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 		const identity = { suitIndex, rank: next_rank };
 
 		// Note that a colour clue always looks direct
-		const ignoreOrders = getIgnoreOrders(game, next_rank - old_play_stacks[suitIndex] - 1, suitIndex);
+		const possibly_bluff = game.level >= LEVEL.BLUFFS && already_connected.length === 1;
+		const ignoreOrders = getIgnoreOrders(game, next_rank - old_play_stacks[suitIndex] - 1, suitIndex, possibly_bluff);
 		const looksDirect = focus_thoughts.identity({ symmetric: true }) === undefined;
 
 		const connect_options = { knownOnly: action.hypothetical ? [state.ourPlayerIndex] : [], bluffed };
@@ -342,7 +343,8 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 		// Try looking for all connecting cards
 		while (next_rank <= rank) {
 			const identity = { suitIndex, rank: next_rank };
-			const ignoreOrders = getIgnoreOrders(game, next_rank - old_play_stacks[suitIndex] - 1, suitIndex);
+			const possibly_bluff = game.level >= LEVEL.BLUFFS && already_connected.length === 1;
+			const ignoreOrders = getIgnoreOrders(game, next_rank - old_play_stacks[suitIndex] - 1, suitIndex, possibly_bluff);
 			const connect_options = { knownOnly: action.hypothetical ? [state.ourPlayerIndex] : [], bluffed };
 			const connecting = find_connecting(game, action, identity, looksDirect, thinks_stall, already_connected, ignoreOrders, connect_options);
 

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -115,8 +115,12 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 	let already_connected = [focus];
 
 	let finesses = 0, bluffed = false;
+	const max_rank = state.max_ranks[suitIndex];
 
-	while (next_rank < state.max_ranks[suitIndex]) {
+	// With trash finesses, we can "connect" up to the max rank since our card may be trash.
+	const max_connecting_rank = game.level >= LEVEL.TRASH_MOVES ? max_rank : max_rank - 1;
+
+	while (next_rank <= max_connecting_rank) {
 		const identity = { suitIndex, rank: next_rank };
 
 		// Note that a colour clue always looks direct
@@ -148,8 +152,8 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 			if (bluff)
 				bluffed = true;
 
-			// Even if a finesse is possible, it might not be a finesse (unless the card is critical)
-			if (!state.isCritical(identity))
+			// Even if a finesse is possible, it might not be a finesse (unless the card is critical on chop)
+			if (!chop || !state.isCritical(identity))
 				focus_possible.push({ suitIndex, rank: next_rank, save: false, connections: connections.slice(), interp: CLUE_INTERP.PLAY });
 		}
 		else if (type === 'playable' && layered && !state.isCritical(identity)) {
@@ -188,6 +192,37 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 				continue;
 			logger.info('found connections:', logConnections(connections, id));
 			focus_possible.push({ ...id, save: false, connections, interp: CLUE_INTERP.PLAY });
+		}
+	}
+	// If we can't have the next card (either because we stacked beyond the max rank or
+	// we know the identity of our card cannot be the next rank), we should consider a
+	// trash finesse.
+	if (game.level >= LEVEL.TRASH_MOVES && !focus_thoughts.possible.has(next_identity) && finesses > 0) {
+		const connected_finesses = connections.filter(conn => conn.type === 'finesse' && !conn.bluff && !conn.hidden);
+		const possible_trash = focus_thoughts.possible.filter(id => state.isBasicTrash(id) || connected_finesses.some(cf => cf.identities.some(cid => cid.suitIndex === id.suitIndex && cid.rank === id.rank)));
+		const tf_connections = connections.slice();
+		// The connection is only a bluff if we didn't find the expected rank playable.
+		tf_connections[0].possibly_bluff = tf_connections[0].bluff;
+
+		// In order to recognize a colour trash finesse, either
+		// 1. The connecting plays before the target don't connect to the target, or
+		let lastPlayer = action.giver;
+		let ci = 0;
+		while (ci < connections.length && connections[ci].reacting) {
+			if (!inBetween(state.numPlayers, connections[ci].reacting, lastPlayer, action.target))
+				break;
+			lastPlayer = connections[ci].reacting;
+			ci++;
+		}
+		const no_connecting_play = ci > 0 && connections[ci-1].identities.every(id => id.suitIndex !== suitIndex);
+
+		// 2. The target knows their card matches a finesse or must be trash.
+		const card_matches_last_play = focus_thoughts.possible.every(id => possible_trash.includes(id));
+
+		if (no_connecting_play || card_matches_last_play) {
+			logger.info('found possible trash finesse:', logConnections(tf_connections, possible_trash));
+			for (const id of possible_trash)
+				focus_possible.push({ ...id, save: false, connections: tf_connections, interp: CLUE_INTERP.TRASH_FINESSE });
 		}
 	}
 

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -6,11 +6,11 @@ import { find_trash_finesses, is_intermediate_bluff_target } from './connection-
 import { find_connecting } from './connecting-cards.js';
 import { cardTouched, colourableSuits, variantRegexes } from '../../../variants.js';
 import { finalize_connections } from './interpret-clue.js';
+import { is_trash_clue } from './interpret-cm.js';
 import * as Utils from '../../../tools/util.js';
 
 import logger from '../../../tools/logger.js';
 import { logCard, logConnections } from '../../../tools/log.js';
-import { is_trash_clue } from './interpret-cm.js';
 
 /**
  * @typedef {import('../../h-group.js').default} Game
@@ -449,36 +449,21 @@ export function find_trash_push(game, action, focusResult, thinks_stall) {
 		// potential play.
 		let before_player = target;
 
-		let looksDirect = true;
-
 		// Try looking for all connecting cards
 		while (next_rank > state.play_stacks[suitIndex]) {
 			const identity = { suitIndex, rank: next_rank };
 			const ignoreOrders = getIgnoreOrders(game, next_rank - state.play_stacks[suitIndex] - 1, suitIndex);
 			const conn_player_order = playersBetween(state.numPlayers, giver, before_player).reverse();
 			const connect_options = { knownOnly: action.hypothetical ? [state.ourPlayerIndex] : [], bluffed, playerOrder: conn_player_order, assumeTruth: true, immediate: true };
-			const connecting = find_connecting(game, action, identity, looksDirect, thinks_stall, already_connected, ignoreOrders, connect_options);
+			const connecting = find_connecting(game, action, identity, /*looksDirect=*/true, thinks_stall, already_connected, ignoreOrders, connect_options);
 
 			if (connecting.length === 0)
 				break;
 
-			const { type, order } = connecting.at(-1);
-			const card = state.deck[order];
+			const { type } = connecting.at(-1);
 
 			if (type === 'terminate')
 				break;
-
-			if (card.newly_clued && common.thoughts[order].possible.length > 1 && focus_thoughts.inferred.has(identity)) {
-				// Trying to use a newly known/playable connecting card, but the focused card could be that
-				// e.g. If two 4s are clued (all other 4s visible), the other 4 should not connect and render this card with only one inference
-				logger.warn(`blocked connection - focused card could be ${logCard(identity)}`);
-				break;
-			}
-
-			if (type === 'finesse') {
-				// A finesse proves that this is not direct
-				looksDirect = focus_thoughts.identity() === undefined;
-			}
 
 			before_player = connecting[0].reacting;
 			connections = connecting.concat(connections);

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -1,7 +1,7 @@
 import { CLUE } from '../../../constants.js';
 import { CLUE_INTERP, FOCUS_INTERP, LEVEL } from '../h-constants.js';
 import { getIgnoreOrders } from '../../../basics/hanabi-util.js';
-import { rankLooksPlayable } from '../hanabi-logic.js';
+import { inBetween, playersBetween, rankLooksPlayable } from '../hanabi-logic.js';
 import { is_intermediate_bluff_target } from './connection-helper.js';
 import { find_connecting } from './connecting-cards.js';
 import { cardTouched, colourableSuits, variantRegexes } from '../../../variants.js';
@@ -93,9 +93,8 @@ export function colour_save(game, identity, action, focus, loaded) {
  * @param {FocusResult} focusResult
  * @param {Set<number>} thinks_stall
  * @param {boolean} loaded
- * @param {typeof FOCUS_INTERP[keyof typeof FOCUS_INTERP]} focus_interp
  */
-function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, loaded, focus_interp) {
+function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, loaded) {
 	const { common, state } = game;
 	const { focus, chop } = focusResult;
 	const focus_thoughts = common.thoughts[focus];
@@ -146,14 +145,8 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 				break;
 			}
 
-			if (bluff) {
+			if (bluff)
 				bluffed = true;
-
-				if (focus_interp === FOCUS_INTERP.TRASH_PUSH) {
-					logger.warn('blocked bluff on trash push');
-					break;
-				}
-			}
 
 			// Even if a finesse is possible, it might not be a finesse (unless the card is critical)
 			if (!state.isCritical(identity))
@@ -178,7 +171,7 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 	state.play_stacks = old_play_stacks;
 
 	const next_identity = { suitIndex, rank: next_rank };
-	if ((focus_interp === FOCUS_INTERP.TRASH_PUSH || cardTouched(next_identity, state.variant, action.clue)) && focus_thoughts.possible.has(next_identity)) {
+	if (cardTouched(next_identity, state.variant, action.clue) && focus_thoughts.possible.has(next_identity)) {
 		logger.info('found connections:', logConnections(connections, next_identity));
 
 		// Our card could be the final rank that we can't find
@@ -369,9 +362,31 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 			const tf_connections = connections.slice();
 			// The connection is only a bluff if we didn't find the expected rank playable.
 			tf_connections[0].possibly_bluff = tf_connections[0].bluff;
-			logger.info('found possible trash finesse:', logConnections(tf_connections, possible_trash));
-			for (const id of possible_trash)
-				focus_possible.push({ ...id, save: false, connections: tf_connections, interp: CLUE_INTERP.TRASH_FINESSE });
+
+			// In order to recognize a rank trash finesse, either
+			// 1. The connecting plays before the target don't connect to the target, or
+			let lastPlayer = giver;
+			let ci = 0;
+			while (ci < connections.length && connections[ci].reacting) {
+				if (!inBetween(state.numPlayers, connections[ci].reacting, lastPlayer, target))
+					break;
+				lastPlayer = connections[ci].reacting;
+				ci++;
+			}
+			const no_connecting_play = ci > 0 && connections[ci-1].identities.every(id => id.suitIndex !== suitIndex || id.rank >= rank);
+
+			// 2. The target knows their card must either be trash or match the last play.
+			const card_matches_last_play = next_rank > rank && focus_thoughts.possible.every(id => state.isBasicTrash(id) || id.suitIndex === suitIndex);
+
+			if (no_connecting_play || card_matches_last_play) {
+				logger.info('found possible trash finesse:', logConnections(tf_connections, possible_trash));
+				for (const id of possible_trash)
+					focus_possible.push({ ...id, save: false, connections: tf_connections, interp: CLUE_INTERP.TRASH_FINESSE });
+			}
+			if (card_matches_last_play) {
+				// The card may still have the real identity, however, we must treat it as a trash finesse.
+				focus_possible.push({ suitIndex, rank, save: false, connections: tf_connections, interp: CLUE_INTERP.TRASH_FINESSE });
+			}
 			continue;
 		}
 
@@ -407,6 +422,111 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 }
 
 /**
+ * Returns all the valid focus possibilities of the focused trash pushed card.
+ * @param {Game} game
+ * @param {ClueAction} action
+ * @param {FocusResult} focusResult
+ * @param {Set<number>} thinks_stall
+ */
+export function find_trash_push(game, action, focusResult, thinks_stall) {
+	const { common, state } = game;
+	const { giver, target } = action;
+	const { focus } = focusResult;
+	const focus_thoughts = common.thoughts[focus];
+
+	/** @type {FocusPossibility[]} */
+	const focus_possible = [];
+
+	// Consider whether the card can be played.
+	for (const id of focus_thoughts.possible) {
+		if (state.isBasicTrash(id))
+			continue;
+		const { suitIndex, rank } = id;
+		const wrong_prompts = new Set();
+		let next_rank = rank - 1;
+
+		if (!focus_thoughts.possible.some(id => id.suitIndex === suitIndex && id.rank >= next_rank))
+			continue;
+
+		/** @type {Connection[]} */
+		let connections = [];
+		let finesses = 0;
+		let already_connected = [focus];
+		const bluffed = false;
+
+		// Trash pushes need to be playable by the target's turn. Each player
+		// between the giver and the target in order will be able to provide
+		// one card each. We search backwards from the target to find the
+		// last possible player as earlier players will see a later player's
+		// potential play.
+		const before_player = target;
+
+		let looksDirect = true;
+
+		// Try looking for all connecting cards
+		while (next_rank > state.play_stacks[suitIndex]) {
+			const identity = { suitIndex, rank: next_rank };
+			const ignoreOrders = getIgnoreOrders(game, next_rank - state.play_stacks[suitIndex] - 1, suitIndex);
+			const conn_player_order = playersBetween(state.numPlayers, giver, before_player).reverse();
+			const connect_options = { knownOnly: action.hypothetical ? [state.ourPlayerIndex] : [], bluffed, playerOrder: conn_player_order, assumeTruth: true, immediate: true };
+			const connecting = find_connecting(game, action, identity, looksDirect, thinks_stall, already_connected, ignoreOrders, connect_options);
+
+			if (connecting.length === 0)
+				break;
+
+			const { type, order } = connecting.at(-1);
+			const card = state.deck[order];
+
+			if (type === 'terminate') {
+				// Trying to look for the same identity as the focused card and being "wrong prompted"
+				if (!focus_thoughts.inferred.has(identity)) {
+					for (const { reacting } of connecting)
+						wrong_prompts.add(reacting);
+				}
+				break;
+			}
+
+			if (card.newly_clued && common.thoughts[order].possible.length > 1 && focus_thoughts.inferred.has(identity)) {
+				// Trying to use a newly known/playable connecting card, but the focused card could be that
+				// e.g. If two 4s are clued (all other 4s visible), the other 4 should not connect and render this card with only one inference
+				logger.warn(`blocked connection - focused card could be ${logCard(identity)}`);
+				break;
+			}
+
+			finesses += connecting.filter(conn => conn.type === 'finesse').length;
+			// Unnecessary check since trash push is level 14.
+			if (game.level === 1 && finesses === 2) {
+				logger.warn('blocked double finesse at level 1');
+				break;
+			}
+
+			if (type === 'finesse') {
+				// A finesse proves that this is not direct
+				looksDirect = focus_thoughts.identity() === undefined;
+			}
+
+			connections = connecting.concat(connections);
+			already_connected = already_connected.concat(connecting.map(conn => conn.order));
+
+			next_rank--;
+		}
+
+		if (next_rank > state.play_stacks[suitIndex]) {
+			logger.warn(`couldn't find needed plays ${logConnections(connections, id)} for identity ${logCard(id)}`);
+			continue;
+		}
+
+		logger.info('found connections:', logConnections(connections, id));
+
+		// Connected cards can stack up to this rank
+		if (next_rank === state.play_stacks[suitIndex])
+			focus_possible.push({ suitIndex, rank, save: false, connections, interp: CLUE_INTERP.PLAY, illegal: false });
+	}
+
+	return focus_possible;
+}
+
+/**
  * Finds all the valid focus possibilities from the given clue.
  * @param {Game} game
  * @param {ClueAction} action
@@ -422,12 +542,12 @@ export function find_focus_possible(game, action, focusResult, thinks_stall, loa
 	logger.debug('play/hypo/max stacks in clue interpretation:', state.play_stacks, common.hypo_stacks, state.max_ranks);
 
 	const focus_possible = focus_interp === FOCUS_INTERP.TRASH_PUSH ?
-		state.variant.suits.flatMap(s => find_colour_focus(game, state.variant.suits.indexOf(s), action, focusResult, thinks_stall, loaded, focus_interp)) :
+		find_trash_push(game, action, focusResult, thinks_stall) :
 		clue.type === CLUE.COLOUR ?
 			state.variant.suits
 				.filter(s => Utils.combineRegex(variantRegexes.rainbowish, variantRegexes.prism).test(s))
 				.concat(colourableSuits(state.variant)[clue.value])
-				.flatMap(s => find_colour_focus(game, state.variant.suits.indexOf(s), action, focusResult, thinks_stall, loaded, focus_interp)) :
+				.flatMap(s => find_colour_focus(game, state.variant.suits.indexOf(s), action, focusResult, thinks_stall, loaded)) :
 			find_rank_focus(game, clue.value, action, focusResult, thinks_stall, loaded);
 
 	// Remove play duplicates (since save overrides play)

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -153,8 +153,8 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 			if (bluff)
 				bluffed = true;
 
-			// Even if a finesse is possible, it might not be a finesse (unless the card is critical on chop)
-			if (!chop || !state.isCritical(identity))
+			// Even if a finesse is possible, it might not be a finesse (unless the card is critical)
+			if (!state.isCritical(identity))
 				focus_possible.push({ suitIndex, rank: next_rank, save: false, connections: connections.slice(), interp: CLUE_INTERP.PLAY });
 		}
 		else if (type === 'playable' && layered && !state.isCritical(identity)) {
@@ -287,14 +287,13 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 			focus_possible.some(fp => fp.suitIndex === suitIndex && fp.rank === rank))
 			continue;
 
-		let certain_trash_finesse = false;
 		if (rank === next_rank) {
 			focus_possible.push({ suitIndex, rank, save: false, connections: [], interp: CLUE_INTERP.PLAY });
 
 			if (!possible_trash_finesse_target)
 				continue;
-			certain_trash_finesse = true;
 		}
+		const certain_trash_finesse = rank === next_rank && possible_trash_finesse_target;
 
 		/** @type {Connection[]} */
 		let connections = [];
@@ -429,7 +428,6 @@ export function find_trash_push(game, action, focusResult, thinks_stall) {
 		if (state.isBasicTrash(id))
 			continue;
 		const { suitIndex, rank } = id;
-		const wrong_prompts = new Set();
 		let next_rank = rank - 1;
 
 		if (!focus_thoughts.possible.some(id => id.suitIndex === suitIndex && id.rank >= next_rank))
@@ -437,7 +435,6 @@ export function find_trash_push(game, action, focusResult, thinks_stall) {
 
 		/** @type {Connection[]} */
 		let connections = [];
-		let finesses = 0;
 		let already_connected = [focus];
 		const bluffed = false;
 
@@ -464,26 +461,13 @@ export function find_trash_push(game, action, focusResult, thinks_stall) {
 			const { type, order } = connecting.at(-1);
 			const card = state.deck[order];
 
-			if (type === 'terminate') {
-				// Trying to look for the same identity as the focused card and being "wrong prompted"
-				if (!focus_thoughts.inferred.has(identity)) {
-					for (const { reacting } of connecting)
-						wrong_prompts.add(reacting);
-				}
+			if (type === 'terminate')
 				break;
-			}
 
 			if (card.newly_clued && common.thoughts[order].possible.length > 1 && focus_thoughts.inferred.has(identity)) {
 				// Trying to use a newly known/playable connecting card, but the focused card could be that
 				// e.g. If two 4s are clued (all other 4s visible), the other 4 should not connect and render this card with only one inference
 				logger.warn(`blocked connection - focused card could be ${logCard(identity)}`);
-				break;
-			}
-
-			finesses += connecting.filter(conn => conn.type === 'finesse').length;
-			// Unnecessary check since trash push is level 14.
-			if (game.level === 1 && finesses === 2) {
-				logger.warn('blocked double finesse at level 1');
 				break;
 			}
 

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -407,7 +407,7 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 			// 1. The connecting plays before the target don't connect to the target, or
 			let lastPlayer = giver;
 			let ci = 0;
-			while (ci < connections.length && connections[ci].reacting) {
+			while (ci < connections.length) {
 				if (!inBetween(state.numPlayers, connections[ci].reacting, lastPlayer, target))
 					break;
 				lastPlayer = connections[ci].reacting;
@@ -415,8 +415,11 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 			}
 			const no_connecting_play = ci > 0 && connections[ci-1].identities.every(id => id.suitIndex !== suitIndex || id.rank >= rank);
 
-			// 2. The target knows their card must either be trash or match the last play.
-			const card_matches_last_play = next_rank > rank && focus_thoughts.possible.every(id => state.isBasicTrash(id) || id.suitIndex === suitIndex);
+			// 2. The target knows their card must either be trash or match a reverse finesse play.
+			const matching_play_index = connections.findIndex(conn => conn.type === 'finesse' && conn.identities.some(id => id.suitIndex === suitIndex && id.rank === rank));
+			const card_matches_last_play = next_rank > rank && focus_thoughts.possible.every(id =>
+				state.isBasicTrash(id) ||
+				matching_play_index >= ci && id.suitIndex === suitIndex);
 
 			if (no_connecting_play || card_matches_last_play) {
 				logger.info('found possible trash finesse:', logConnections(tf_connections, possible_trash));

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -387,7 +387,8 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 				// The card may still have the real identity, however, we must treat it as a trash finesse.
 				focus_possible.push({ suitIndex, rank, save: false, connections: tf_connections, interp: CLUE_INTERP.TRASH_FINESSE });
 			}
-			continue;
+			if (no_connecting_play || card_matches_last_play)
+				continue;
 		}
 
 		const next_identity = { suitIndex, rank: next_rank };

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -2,7 +2,7 @@ import { CLUE } from '../../../constants.js';
 import { CLUE_INTERP, FOCUS_INTERP, LEVEL } from '../h-constants.js';
 import { getIgnoreOrders } from '../../../basics/hanabi-util.js';
 import { inBetween, playersBetween, rankLooksPlayable } from '../hanabi-logic.js';
-import { is_intermediate_bluff_target } from './connection-helper.js';
+import { is_intermediate_bluff_target, is_trash_finesse_target } from './connection-helper.js';
 import { find_connecting } from './connecting-cards.js';
 import { cardTouched, colourableSuits, variantRegexes } from '../../../variants.js';
 import { finalize_connections } from './interpret-clue.js';
@@ -198,7 +198,8 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 	// If we can't have the next card (either because we stacked beyond the max rank or
 	// we know the identity of our card cannot be the next rank), we should consider a
 	// trash finesse.
-	if (game.level >= LEVEL.TRASH_MOVES && !focus_thoughts.possible.has(next_identity) && finesses > 0) {
+	const possible_trash_finesse_target = game.level >= LEVEL.TRASH_MOVES && is_trash_finesse_target(game, focus);
+	if (possible_trash_finesse_target && !focus_thoughts.possible.has(next_identity) && finesses > 0) {
 		// In order to recognize a colour trash finesse, either
 		// 1. The connecting plays before the target don't connect to the target, or
 		let lastPlayer = action.giver;
@@ -309,6 +310,7 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 	}
 
 	const old_play_stacks = state.play_stacks;
+	const possible_trash_finesse_target = game.level >= LEVEL.TRASH_MOVES && is_trash_finesse_target(game, focus);
 
 	// Play clue
 	for (let suitIndex = 0; suitIndex < state.variant.suits.length; suitIndex++) {
@@ -321,7 +323,7 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 			continue;
 
 		let certain_trash_finesse = false;
-		const possible_trash = game.level >= LEVEL.TRASH_MOVES && focus_thoughts.possible.filter(id => state.isBasicTrash(id)) || [];
+		const possible_trash = possible_trash_finesse_target && focus_thoughts.possible.filter(id => state.isBasicTrash(id)) || [];
 
 		if (rank === next_rank) {
 			focus_possible.push({ suitIndex, rank, save: false, connections: [], interp: CLUE_INTERP.PLAY });

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -281,9 +281,15 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 			focus_possible.some(fp => fp.suitIndex === suitIndex && fp.rank === rank))
 			continue;
 
+		let certain_trash_finesse = false;
+		const possible_trash = game.level >= LEVEL.TRASH_MOVES && focus_thoughts.possible.filter(id => state.isBasicTrash(id)) || [];
+
 		if (rank === next_rank) {
 			focus_possible.push({ suitIndex, rank, save: false, connections: [], interp: CLUE_INTERP.PLAY });
-			continue;
+
+			if (possible_trash.length === 0)
+				continue;
+			certain_trash_finesse = true;
 		}
 
 		/** @type {Connection[]} */
@@ -338,7 +344,7 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 					bluffed = true;
 
 				// Even if a finesse is possible, it might not be a finesse (unless the card is critical)
-				if ((rank === next_rank || positional) && !state.isCritical(identity))
+				if (!certain_trash_finesse && (rank === next_rank || positional) && !state.isCritical(identity))
 					focus_possible.push({ ...identity, save: false, connections: connections.slice(), interp: CLUE_INTERP.PLAY });
 			}
 			else if (type === 'playable' && layered && (rank === next_rank || positional) && !state.isCritical(identity)) {
@@ -359,9 +365,19 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 		// Restore play stacks
 		state.play_stacks = old_play_stacks;
 
+		if (possible_trash.length > 0 && connections.length > 0) {
+			const tf_connections = connections.slice();
+			// The connection is only a bluff if we didn't find the expected rank playable.
+			tf_connections[0].possibly_bluff = tf_connections[0].bluff;
+			logger.info('found possible trash finesse:', logConnections(tf_connections, possible_trash));
+			for (const id of possible_trash)
+				focus_possible.push({ ...id, save: false, connections: tf_connections, interp: CLUE_INTERP.TRASH_FINESSE });
+			continue;
+		}
+
 		const next_identity = { suitIndex, rank: next_rank };
 		if (!positional && next_rank > rank) {
-			logger.warn(`stacked beyond clued rank ${logConnections(connections, next_identity)}, ignoring`);
+			logger.warn(`stacked beyond clued rank ${logConnections(connections, next_identity)}, ignoring finesse possibility`);
 			continue;
 		}
 

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -2,7 +2,7 @@ import { CLUE } from '../../../constants.js';
 import { CLUE_INTERP, FOCUS_INTERP, LEVEL } from '../h-constants.js';
 import { getIgnoreOrders } from '../../../basics/hanabi-util.js';
 import { inBetween, playersBetween, rankLooksPlayable } from '../hanabi-logic.js';
-import { is_intermediate_bluff_target, is_trash_finesse_target } from './connection-helper.js';
+import { find_trash_finesses, is_intermediate_bluff_target, is_trash_finesse_target } from './connection-helper.js';
 import { find_connecting } from './connecting-cards.js';
 import { cardTouched, colourableSuits, variantRegexes } from '../../../variants.js';
 import { finalize_connections } from './interpret-clue.js';
@@ -198,45 +198,10 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 	// If we can't have the next card (either because we stacked beyond the max rank or
 	// we know the identity of our card cannot be the next rank), we should consider a
 	// trash finesse.
-	const possible_trash_finesse_target = game.level >= LEVEL.TRASH_MOVES && is_trash_finesse_target(game, focus);
-	if (possible_trash_finesse_target && !focus_thoughts.possible.has(next_identity) && finesses > 0) {
-		// In order to recognize a colour trash finesse, either
-		// 1. The connecting plays before the target don't connect to the target, or
-		let lastPlayer = action.giver;
-		let ci = 0;
-		let ourMaxRank = 0;
-		for (const id of focus_thoughts.possible) {
-			if (id.suitIndex === suitIndex && id.rank > ourMaxRank)
-				ourMaxRank = id.rank;
-		}
-		while (ci < connections.length && connections[ci].reacting) {
-			if (!inBetween(state.numPlayers, connections[ci].reacting, lastPlayer, action.target))
-				break;
-			lastPlayer = connections[ci].reacting;
-			ci++;
-		}
-		const no_connecting_play = ci > 0 && connections[ci-1].identities.every(id => id.suitIndex !== suitIndex || id.rank >= ourMaxRank);
-
-		// Can only reverse trash finesse before end game.
-		const connected_reverse_finesses = state.inEndgame() ? [] : connections.filter((conn, conn_i) => conn_i >= ci && conn.type === 'finesse');
-		const possible_trash = focus_thoughts.possible.filter(id =>
-			state.isBasicTrash(id) ||
-			connected_reverse_finesses.some(cf => cf.identities.some(cid => cid.suitIndex === id.suitIndex && cid.rank === id.rank)));
-		const tf_connections = connections.slice();
-		// The connection is only a bluff if we didn't find the expected rank playable.
-		tf_connections[0].possibly_bluff = tf_connections[0].bluff;
-
-		// 2. The target knows their card must either be trash or match a reverse finesse play.
-		const card_matches_last_play = focus_thoughts.possible.every(id =>
-			possible_trash.includes(id)
-		);
-
-		if (no_connecting_play || card_matches_last_play) {
-			logger.info('found possible trash finesse:', logConnections(tf_connections, possible_trash));
-			for (const id of possible_trash)
-				focus_possible.push({ ...id, save: false, connections: tf_connections, interp: CLUE_INTERP.TRASH_FINESSE });
-		}
-	}
+	const trash_finesses = focus_thoughts.possible.has(next_identity) ? [] :
+		find_trash_finesses(game, action, focus, connections, {suitIndex, rank: next_identity.rank - 1}, finesses);
+	for (const fp of trash_finesses)
+		focus_possible.push(fp);
 
 	// Save clue on chop
 	if (chop) {
@@ -407,41 +372,12 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 		// Restore play stacks
 		state.play_stacks = old_play_stacks;
 
-		if (possible_trash.length > 0 && connections.length > 0) {
-			const tf_connections = connections.slice();
-			// The connection is only a bluff if we didn't find the expected rank playable.
-			tf_connections[0].possibly_bluff = tf_connections[0].bluff;
-
-			// In order to recognize a rank trash finesse, either
-			// 1. The connecting plays before the target don't connect to the target, or
-			let lastPlayer = giver;
-			let ci = 0;
-			while (ci < connections.length) {
-				if (!inBetween(state.numPlayers, connections[ci].reacting, lastPlayer, target))
-					break;
-				lastPlayer = connections[ci].reacting;
-				ci++;
-			}
-			const no_connecting_play = ci > 0 && connections[ci-1].identities.every(id => id.suitIndex !== suitIndex || id.rank >= rank);
-
-			// 2. The target knows their card must either be trash or match a reverse finesse play before end game.
-			const matching_play_index = state.inEndgame() ? -1 : connections.findIndex((conn, index) => index >= ci && conn.type === 'finesse' && conn.identities.some(id => id.suitIndex === suitIndex && id.rank === rank));
-			const card_matches_last_play = next_rank > rank && focus_thoughts.possible.every(id =>
-				state.isBasicTrash(id) ||
-				matching_play_index != -1 && id.suitIndex === suitIndex);
-
-			if (no_connecting_play || card_matches_last_play) {
-				logger.info('found possible trash finesse:', logConnections(tf_connections, possible_trash));
-				for (const id of possible_trash)
-					focus_possible.push({ ...id, save: false, connections: tf_connections, interp: CLUE_INTERP.TRASH_FINESSE });
-			}
-			if (card_matches_last_play) {
-				// The card may still have the real identity, however, we must treat it as a trash finesse.
-				focus_possible.push({ suitIndex, rank, save: false, connections: tf_connections, interp: CLUE_INTERP.TRASH_FINESSE });
-			}
-			if (no_connecting_play || card_matches_last_play)
-				continue;
-		}
+		// If we can't have the next card (because we stacked beyond the clue rank,
+		// we should consider a trash finesse.
+		const trash_finesses = next_rank <= rank ? [] :
+			find_trash_finesses(game, action, focus, connections, { suitIndex, rank: next_rank - 1 });
+		for (const fp of trash_finesses)
+			focus_possible.push(fp);
 
 		const next_identity = { suitIndex, rank: next_rank };
 		if (!positional && next_rank > rank) {

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -198,12 +198,6 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 	// we know the identity of our card cannot be the next rank), we should consider a
 	// trash finesse.
 	if (game.level >= LEVEL.TRASH_MOVES && !focus_thoughts.possible.has(next_identity) && finesses > 0) {
-		const connected_finesses = connections.filter(conn => conn.type === 'finesse' && !conn.bluff && !conn.hidden);
-		const possible_trash = focus_thoughts.possible.filter(id => state.isBasicTrash(id) || connected_finesses.some(cf => cf.identities.some(cid => cid.suitIndex === id.suitIndex && cid.rank === id.rank)));
-		const tf_connections = connections.slice();
-		// The connection is only a bluff if we didn't find the expected rank playable.
-		tf_connections[0].possibly_bluff = tf_connections[0].bluff;
-
 		// In order to recognize a colour trash finesse, either
 		// 1. The connecting plays before the target don't connect to the target, or
 		let lastPlayer = action.giver;
@@ -216,8 +210,19 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 		}
 		const no_connecting_play = ci > 0 && connections[ci-1].identities.every(id => id.suitIndex !== suitIndex);
 
+		const connected_finesses = connections.filter((conn, conn_i) => conn_i < ci && conn.type === 'finesse');
+		const connected_reverse_finesses = connections.filter((conn, conn_i) => conn_i >= ci && conn.type === 'finesse');
+		const possible_trash = focus_thoughts.possible.filter(id =>
+			state.isBasicTrash(id) ||
+			connected_reverse_finesses.some(cf => cf.identities.some(cid => cid.suitIndex === id.suitIndex && cid.rank === id.rank)));
+		const tf_connections = connections.slice();
+		// The connection is only a bluff if we didn't find the expected rank playable.
+		tf_connections[0].possibly_bluff = tf_connections[0].bluff;
+
 		// 2. The target knows their card matches a finesse or must be trash.
-		const card_matches_last_play = focus_thoughts.possible.every(id => possible_trash.includes(id));
+		const card_matches_last_play = focus_thoughts.possible.every(id =>
+			possible_trash.includes(id) ||
+			connected_finesses.some(cf => cf.identities.some(cid => cid.suitIndex === id.suitIndex && cid.rank === id.rank)));
 
 		if (no_connecting_play || card_matches_last_play) {
 			logger.info('found possible trash finesse:', logConnections(tf_connections, possible_trash));

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -1,7 +1,7 @@
 import { CLUE } from '../../../constants.js';
 import { CLUE_INTERP, FOCUS_INTERP, LEVEL } from '../h-constants.js';
 import { getIgnoreOrders } from '../../../basics/hanabi-util.js';
-import { inBetween, playersBetween, rankLooksPlayable } from '../hanabi-logic.js';
+import { playersBetween, rankLooksPlayable } from '../hanabi-logic.js';
 import { find_trash_finesses, is_intermediate_bluff_target, is_trash_finesse_target } from './connection-helper.js';
 import { find_connecting } from './connecting-cards.js';
 import { cardTouched, colourableSuits, variantRegexes } from '../../../variants.js';

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -288,12 +288,10 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 			continue;
 
 		let certain_trash_finesse = false;
-		const possible_trash = possible_trash_finesse_target && focus_thoughts.possible.filter(id => state.isBasicTrash(id)) || [];
-
 		if (rank === next_rank) {
 			focus_possible.push({ suitIndex, rank, save: false, connections: [], interp: CLUE_INTERP.PLAY });
 
-			if (possible_trash.length === 0)
+			if (!possible_trash_finesse_target)
 				continue;
 			certain_trash_finesse = true;
 		}

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -1,5 +1,5 @@
 import { CLUE } from '../../../constants.js';
-import { CLUE_INTERP, LEVEL } from '../h-constants.js';
+import { CLUE_INTERP, FOCUS_INTERP, LEVEL } from '../h-constants.js';
 import { getIgnoreOrders } from '../../../basics/hanabi-util.js';
 import { rankLooksPlayable } from '../hanabi-logic.js';
 import { is_intermediate_bluff_target } from './connection-helper.js';
@@ -93,8 +93,9 @@ export function colour_save(game, identity, action, focus, loaded) {
  * @param {FocusResult} focusResult
  * @param {Set<number>} thinks_stall
  * @param {boolean} loaded
+ * @param {typeof FOCUS_INTERP[keyof typeof FOCUS_INTERP]} focus_interp
  */
-function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, loaded) {
+function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, loaded, focus_interp) {
 	const { common, state } = game;
 	const { focus, chop } = focusResult;
 	const focus_thoughts = common.thoughts[focus];
@@ -145,8 +146,14 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 				break;
 			}
 
-			if (bluff)
+			if (bluff) {
 				bluffed = true;
+
+				if (focus_interp === FOCUS_INTERP.TRASH_PUSH) {
+					logger.warn('blocked bluff on trash push');
+					break;
+				}
+			}
 
 			// Even if a finesse is possible, it might not be a finesse (unless the card is critical)
 			if (!state.isCritical(identity))
@@ -171,7 +178,7 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 	state.play_stacks = old_play_stacks;
 
 	const next_identity = { suitIndex, rank: next_rank };
-	if (cardTouched(next_identity, state.variant, action.clue) && focus_thoughts.possible.has(next_identity)) {
+	if ((focus_interp === FOCUS_INTERP.TRASH_PUSH || cardTouched(next_identity, state.variant, action.clue)) && focus_thoughts.possible.has(next_identity)) {
 		logger.info('found connections:', logConnections(connections, next_identity));
 
 		// Our card could be the final rank that we can't find
@@ -390,18 +397,22 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
  * @param {FocusResult} focusResult
  * @param {Set<number>} thinks_stall
  * @param {boolean} loaded
+ * @param {typeof FOCUS_INTERP[keyof typeof FOCUS_INTERP]} focus_interp
+ focus_interp
  */
-export function find_focus_possible(game, action, focusResult, thinks_stall, loaded) {
+export function find_focus_possible(game, action, focusResult, thinks_stall, loaded, focus_interp) {
 	const { common, state } = game;
 	const { clue } = action;
 	logger.debug('play/hypo/max stacks in clue interpretation:', state.play_stacks, common.hypo_stacks, state.max_ranks);
 
-	const focus_possible = clue.type === CLUE.COLOUR ?
-		state.variant.suits
-			.filter(s => Utils.combineRegex(variantRegexes.rainbowish, variantRegexes.prism).test(s))
-			.concat(colourableSuits(state.variant)[clue.value])
-			.flatMap(s => find_colour_focus(game, state.variant.suits.indexOf(s), action, focusResult, thinks_stall, loaded)) :
-		find_rank_focus(game, clue.value, action, focusResult, thinks_stall, loaded);
+	const focus_possible = focus_interp === FOCUS_INTERP.TRASH_PUSH ?
+		state.variant.suits.flatMap(s => find_colour_focus(game, state.variant.suits.indexOf(s), action, focusResult, thinks_stall, loaded, focus_interp)) :
+		clue.type === CLUE.COLOUR ?
+			state.variant.suits
+				.filter(s => Utils.combineRegex(variantRegexes.rainbowish, variantRegexes.prism).test(s))
+				.concat(colourableSuits(state.variant)[clue.value])
+				.flatMap(s => find_colour_focus(game, state.variant.suits.indexOf(s), action, focusResult, thinks_stall, loaded, focus_interp)) :
+			find_rank_focus(game, clue.value, action, focusResult, thinks_stall, loaded);
 
 	// Remove play duplicates (since save overrides play)
 	const filtered_fps = focus_possible.filter((p1, index1) => {

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -203,8 +203,7 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 	// If we can't have the next card (either because we stacked beyond the max rank or
 	// we know the identity of our card cannot be the next rank), we should consider a
 	// trash finesse.
-	const trash_finesses = focus_thoughts.possible.has(next_identity) ? [] :
-		find_trash_finesses(game, action, focus, connections, suitIndex);
+	const trash_finesses = find_trash_finesses(game, action, focus, connections, next_identity);
 	for (const fp of trash_finesses)
 		focus_possible.push(fp);
 
@@ -377,7 +376,7 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 		// If we can't have the next card (because we stacked beyond the clue rank,
 		// we should consider a trash finesse.
 		const trash_finesses = next_rank <= rank ? [] :
-			find_trash_finesses(game, action, focus, connections, suitIndex);
+			find_trash_finesses(game, action, focus, connections, {suitIndex, rank: next_rank});
 		for (const fp of trash_finesses)
 			focus_possible.push(fp);
 

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -2,7 +2,7 @@ import { CLUE } from '../../../constants.js';
 import { CLUE_INTERP, FOCUS_INTERP, LEVEL } from '../h-constants.js';
 import { getIgnoreOrders } from '../../../basics/hanabi-util.js';
 import { playersBetween, rankLooksPlayable } from '../hanabi-logic.js';
-import { find_trash_finesses, is_intermediate_bluff_target, is_trash_finesse_target } from './connection-helper.js';
+import { find_trash_finesses, is_intermediate_bluff_target } from './connection-helper.js';
 import { find_connecting } from './connecting-cards.js';
 import { cardTouched, colourableSuits, variantRegexes } from '../../../variants.js';
 import { finalize_connections } from './interpret-clue.js';
@@ -10,6 +10,7 @@ import * as Utils from '../../../tools/util.js';
 
 import logger from '../../../tools/logger.js';
 import { logCard, logConnections } from '../../../tools/log.js';
+import { is_trash_clue } from './interpret-cm.js';
 
 /**
  * @typedef {import('../../h-group.js').default} Game
@@ -256,7 +257,7 @@ export function rank_save(game, identity, action, focus, loaded) {
  */
 function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) {
 	const { common, state } = game;
-	const { giver, target } = action;
+	const { giver, target, clue } = action;
 	const { focus, chop, positional } = focusResult;
 	const focus_thoughts = common.thoughts[focus];
 
@@ -275,7 +276,7 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 	}
 
 	const old_play_stacks = state.play_stacks;
-	const possible_trash_finesse_target = game.level >= LEVEL.TRASH_MOVES && is_trash_finesse_target(game, focus);
+	const possible_trash_finesse_target = game.level >= LEVEL.TRASH_MOVES && !is_trash_clue(game, giver, clue, target, focus, common);
 
 	// Play clue
 	for (let suitIndex = 0; suitIndex < state.variant.suits.length; suitIndex++) {

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -202,16 +202,21 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 		// 1. The connecting plays before the target don't connect to the target, or
 		let lastPlayer = action.giver;
 		let ci = 0;
+		let ourMaxRank = 0;
+		for (const id of focus_thoughts.possible) {
+			if (id.suitIndex === suitIndex && id.rank > ourMaxRank)
+				ourMaxRank = id.rank;
+		}
 		while (ci < connections.length && connections[ci].reacting) {
 			if (!inBetween(state.numPlayers, connections[ci].reacting, lastPlayer, action.target))
 				break;
 			lastPlayer = connections[ci].reacting;
 			ci++;
 		}
-		const no_connecting_play = ci > 0 && connections[ci-1].identities.every(id => id.suitIndex !== suitIndex);
+		const no_connecting_play = ci > 0 && connections[ci-1].identities.every(id => id.suitIndex !== suitIndex || id.rank >= ourMaxRank);
 
-		const connected_finesses = connections.filter((conn, conn_i) => conn_i < ci && conn.type === 'finesse');
-		const connected_reverse_finesses = connections.filter((conn, conn_i) => conn_i >= ci && conn.type === 'finesse');
+		// Can only reverse trash finesse before end game.
+		const connected_reverse_finesses = state.inEndgame() ? [] : connections.filter((conn, conn_i) => conn_i >= ci && conn.type === 'finesse');
 		const possible_trash = focus_thoughts.possible.filter(id =>
 			state.isBasicTrash(id) ||
 			connected_reverse_finesses.some(cf => cf.identities.some(cid => cid.suitIndex === id.suitIndex && cid.rank === id.rank)));
@@ -219,10 +224,10 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 		// The connection is only a bluff if we didn't find the expected rank playable.
 		tf_connections[0].possibly_bluff = tf_connections[0].bluff;
 
-		// 2. The target knows their card matches a finesse or must be trash.
+		// 2. The target knows their card must either be trash or match a reverse finesse play.
 		const card_matches_last_play = focus_thoughts.possible.every(id =>
-			possible_trash.includes(id) ||
-			connected_finesses.some(cf => cf.identities.some(cid => cid.suitIndex === id.suitIndex && cid.rank === id.rank)));
+			possible_trash.includes(id)
+		);
 
 		if (no_connecting_play || card_matches_last_play) {
 			logger.info('found possible trash finesse:', logConnections(tf_connections, possible_trash));
@@ -415,11 +420,11 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 			}
 			const no_connecting_play = ci > 0 && connections[ci-1].identities.every(id => id.suitIndex !== suitIndex || id.rank >= rank);
 
-			// 2. The target knows their card must either be trash or match a reverse finesse play.
-			const matching_play_index = connections.findIndex(conn => conn.type === 'finesse' && conn.identities.some(id => id.suitIndex === suitIndex && id.rank === rank));
+			// 2. The target knows their card must either be trash or match a reverse finesse play before end game.
+			const matching_play_index = state.inEndgame() ? -1 : connections.findIndex((conn, index) => index >= ci && conn.type === 'finesse' && conn.identities.some(id => id.suitIndex === suitIndex && id.rank === rank));
 			const card_matches_last_play = next_rank > rank && focus_thoughts.possible.every(id =>
 				state.isBasicTrash(id) ||
-				matching_play_index >= ci && id.suitIndex === suitIndex);
+				matching_play_index != -1 && id.suitIndex === suitIndex);
 
 			if (no_connecting_play || card_matches_last_play) {
 				logger.info('found possible trash finesse:', logConnections(tf_connections, possible_trash));

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -199,7 +199,7 @@ function find_colour_focus(game, suitIndex, action, focusResult, thinks_stall, l
 	// we know the identity of our card cannot be the next rank), we should consider a
 	// trash finesse.
 	const trash_finesses = focus_thoughts.possible.has(next_identity) ? [] :
-		find_trash_finesses(game, action, focus, connections, {suitIndex, rank: next_identity.rank - 1}, finesses);
+		find_trash_finesses(game, action, focus, connections, suitIndex);
 	for (const fp of trash_finesses)
 		focus_possible.push(fp);
 
@@ -373,7 +373,7 @@ function find_rank_focus(game, rank, action, focusResult, thinks_stall, loaded) 
 		// If we can't have the next card (because we stacked beyond the clue rank,
 		// we should consider a trash finesse.
 		const trash_finesses = next_rank <= rank ? [] :
-			find_trash_finesses(game, action, focus, connections, { suitIndex, rank: next_rank - 1 });
+			find_trash_finesses(game, action, focus, connections, suitIndex);
 		for (const fp of trash_finesses)
 			focus_possible.push(fp);
 

--- a/src/conventions/h-group/clue-interpretation/focus-possible.js
+++ b/src/conventions/h-group/clue-interpretation/focus-possible.js
@@ -447,7 +447,7 @@ export function find_trash_push(game, action, focusResult, thinks_stall) {
 		// one card each. We search backwards from the target to find the
 		// last possible player as earlier players will see a later player's
 		// potential play.
-		const before_player = target;
+		let before_player = target;
 
 		let looksDirect = true;
 
@@ -480,9 +480,9 @@ export function find_trash_push(game, action, focusResult, thinks_stall) {
 				looksDirect = focus_thoughts.identity() === undefined;
 			}
 
+			before_player = connecting[0].reacting;
 			connections = connecting.concat(connections);
 			already_connected = already_connected.concat(connecting.map(conn => conn.order));
-
 			next_rank--;
 		}
 

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -713,8 +713,16 @@ export function interpret_clue(game, action) {
 	}
 
 	const focus_possible = find_focus_possible(game, action, focusResult, thinks_stall, loaded, focus_interp);
+	const possible_bluff = focus_possible.filter(fp => fp.interp === CLUE_INTERP.PLAY && fp.connections[0]?.bluff);
+	if (possible_bluff.length > 0) {
+		focus_possible.forEach(fp => {
+			if (fp.interp !== CLUE_INTERP.TRASH_FINESSE || fp.connections[0].type !== 'finesse' || fp.connections[0].reacting !== state.nextPlayerIndex(giver))
+				return;
+			fp.illegal = true;
+		});
+	}
 	logger.info('focus possible:', focus_possible.map(({ suitIndex, rank, save, illegal }) => logCard({suitIndex, rank}) + (save ? ' (save)' : ''  + (illegal ? ' (illegal)' : ''))));
-	const consider_trash = focus_possible.some(p => p.interp === CLUE_INTERP.TRASH_FINESSE) &&
+	const consider_trash = focus_possible.some(p => !p.illegal && p.interp === CLUE_INTERP.TRASH_FINESSE) &&
 		(target === state.ourPlayerIndex ||
 			!focus_possible.some(p => !p.illegal && common.thoughts[focus].inferred.has(p) && focused_card.matches(p)));
 	if (consider_trash) {
@@ -724,7 +732,7 @@ export function interpret_clue(game, action) {
 		const tcm_orders = interpret_tcm(game, action, focus, oldCommon, true);
 		perform_cm(state, common, tcm_orders);
 
-		// Further, any play identites are illegal if they could also be trash finesse identites:
+		// Further, any play identities are illegal if they could also be trash finesse identities:
 		for (const fp of focus_possible.filter(p => p.interp === CLUE_INTERP.PLAY)) {
 			if (trash_finesses.some(tf => tf.suitIndex === fp.suitIndex && tf.rank === fp.rank)) {
 				fp.illegal = true;
@@ -779,7 +787,8 @@ export function interpret_clue(game, action) {
 		// We are the clue target, so we need to consider all the (sensible) possibilities of the card
 		if (target === state.ourPlayerIndex) {
 			all_connections = focus_possible.filter(fp =>
-				fp.interp === CLUE_INTERP.TRASH_FINESSE || !isTrash(prev_game.state, prev_game.players[giver], fp, focus, { infer: true, ignoreCM: true }));
+				!fp.illegal && (
+					fp.interp === CLUE_INTERP.TRASH_FINESSE || !isTrash(prev_game.state, prev_game.players[giver], fp, focus, { infer: true, ignoreCM: true })));
 			// For a trash push, we must assume the focus is playable by our turn - no need to look for self connections.
 			if (focus_interp !== FOCUS_INTERP.TRASH_PUSH) {
 				for (const id of common.thoughts[focus].inferred) {

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -719,18 +719,9 @@ export function interpret_clue(game, action) {
 	if (trash_finesses.length > 0 && (target === state.ourPlayerIndex || !focus_possible.some(p => !p.illegal && common.thoughts[focus].inferred.has(p) &&focused_card.matches(p)))) {
 		// If a trash finesse is possible, we must assume one
 		// if possible unless / until the finessed card is not playable.
-		const { possible } = common.thoughts[focus];
-		const new_inferred = possible.intersect(trash_finesses);
-		if (new_inferred.length > 0) {
-			common.updateThoughts(focus, (draft) => {
-				draft.inferred = new_inferred;
-				draft.info_lock = new_inferred;
-				draft.trash = true;
-			});
-			// Trash chop move
-			const tcm_orders = interpret_tcm(game, action, focus, oldCommon, true);
-			perform_cm(state, common, tcm_orders);
-		}
+		// Trash chop move
+		const tcm_orders = interpret_tcm(game, action, focus, oldCommon, true);
+		perform_cm(state, common, tcm_orders);
 
 		// Further, any play identites are illegal if they could also be trash finesse identites:
 		for (const fp of focus_possible.filter(p => p.interp === CLUE_INTERP.PLAY)) {
@@ -741,7 +732,7 @@ export function interpret_clue(game, action) {
 		}
 	}
 
-	const matched_inferences = focus_possible.filter(p => !p.illegal && common.thoughts[focus].inferred.has(p));
+	const matched_inferences = focus_possible.filter(p => !p.illegal && (common.thoughts[focus].inferred.has(p) || p.interp === CLUE_INTERP.TRASH_FINESSE));
 	const old_game = game.minimalCopy();
 
 	// Card matches an inference and not a save/stall

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -721,7 +721,6 @@ export function interpret_clue(game, action) {
 			fp.illegal = true;
 		});
 	}
-	logger.info('focus possible:', focus_possible.map(({ suitIndex, rank, save, illegal }) => logCard({suitIndex, rank}) + (save ? ' (save)' : ''  + (illegal ? ' (illegal)' : ''))));
 	const consider_trash = focus_possible.some(p => !p.illegal && p.interp === CLUE_INTERP.TRASH_FINESSE) &&
 		(target === state.ourPlayerIndex ||
 			!focus_possible.some(p => !p.illegal && common.thoughts[focus].inferred.has(p) && focused_card.matches(p)));
@@ -740,6 +739,7 @@ export function interpret_clue(game, action) {
 			}
 		}
 	}
+	logger.info('focus possible:', focus_possible.map(({ suitIndex, rank, save, illegal }) => logCard({suitIndex, rank}) + (save ? ' (save)' : ''  + (illegal ? ' (illegal)' : ''))));
 
 	const matched_inferences = focus_possible.filter(p => !p.illegal && (
 		common.thoughts[focus].inferred.has(p) ||

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -367,43 +367,6 @@ function try_tccm(game, oldCommon, stall, thinks_stall, target, list, focused_ca
 	}
 }
 
-
-/**
- * Checks whether a Trash Push was performed on the target. The clue must have already been registered.
- * @param {Game} game
- * @param {ClueAction} action
- * @param {number} focus_order
- * @param {Player} oldCommon
- * @returns The order of the trash pushed card.
- */
-export function interpret_tp(game, action, focus_order, oldCommon) {
-	const { common, state } = game;
-	const { clue, target } = action;
-	const focused_card = state.deck[focus_order];
-	const focus_thoughts = common.thoughts[focus_order];
-
-	// A trash push must not save any cards - i.e. must target the chop,
-	// and there must be a card to push.
-	const chop = common.chop(state.hands[target]);
-	if (chop === undefined || !focused_card.newly_clued || !focus_thoughts.chop_when_first_clued)
-		return undefined;
-
-	if (clue.type === CLUE.RANK) {
-		const promised_ids = Utils.range(0, state.variant.suits.length).map(suitIndex => ({ suitIndex, rank: clue.value }));
-
-		if (focus_thoughts.possible.intersect(promised_ids).some(i => !isTrash(state, oldCommon, i, focus_order, { infer: true })))
-			return undefined;
-	}
-	else if (focus_thoughts.possible.some(c => !isTrash(state, oldCommon, c, focus_order, { infer: true })) ||
-		focus_thoughts.inferred.every(i => state.isPlayable(i) && !isTrash(state, oldCommon, i, focus_order, { infer: true }))) {
-		return undefined;
-	}
-
-	logger.highlight('cyan', `trash push on ${logCard(state.deck[chop])} ${chop}`);
-
-	return chop;
-}
-
 /**
  * Interprets the given clue. First tries to look for inferred connecting cards, then attempts to find prompts/finesses.
  * 
@@ -467,11 +430,9 @@ export function interpret_clue(game, action) {
 	logger.info('loaded?', loaded);
 
 
-	let focus_interp = FOCUS_INTERP.NORMAL;
 	const focusResult = determine_focus(game, state.hands[target], common, list, clue);
-	const { positional } = focusResult;
-	let { focus, chop } = focusResult;
-	let focused_card = state.deck[focus];
+	const { positional, focus, chop, focus_interp } = focusResult;
+	const focused_card = state.deck[focus];
 
 	common.updateThoughts(focus, (draft) => { draft.focused = true; });
 	const { fix, rewinded } = apply_good_touch(game, action, oldCommon.thoughts);
@@ -480,7 +441,7 @@ export function interpret_clue(game, action) {
 	if (rewinded)
 		return game;
 
-	if (chop && !action.noRecurse) {
+	if (focus_interp !== FOCUS_INTERP.TRASH_PUSH && chop && !action.noRecurse) {
 		common.updateThoughts(focus, (draft) => { draft.chop_when_first_clued = true; });
 		action.important = !loaded && urgent_save(game, action, focus, oldCommon, prev_game);
 		if (action.important)
@@ -722,19 +683,6 @@ export function interpret_clue(game, action) {
 		game.interpretMove(CLUE_INTERP.FIX);
 		team_elim(game);
 		return game;
-	}
-
-	// Focus adjusting conventions occur just before resolving focus possibilities.
-	if (game.level >= LEVEL.TRASH_MOVES) {
-		const tp = interpret_tp(game, action, focus, oldCommon);
-
-		if (tp !== undefined) {
-			logger.info('trash push, new focus:', tp);
-			focusResult.focus = focus = tp;
-			focusResult.chop = chop = false;
-			focus_interp = FOCUS_INTERP.TRASH_PUSH;
-			focused_card = state.deck[focus];
-		}
 	}
 
 	const focus_possible = find_focus_possible(game, action, focusResult, thinks_stall, loaded, focus_interp);

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -458,7 +458,7 @@ export function interpret_clue(game, action) {
 	logger.info('loaded?', loaded);
 
 
-	const focusResult = determine_focus(game, state.hands[target], common, list, clue);
+	const focusResult = determine_focus(game, state.hands[target], common, list, giver, target, clue);
 	const { positional, focus, chop, focus_interp } = focusResult;
 	const focused_card = state.deck[focus];
 

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -777,60 +777,62 @@ export function interpret_clue(game, action) {
 		if (target === state.ourPlayerIndex) {
 			all_connections = focus_possible.filter(fp =>
 				fp.interp === CLUE_INTERP.TRASH_FINESSE || !isTrash(prev_game.state, prev_game.players[giver], fp, focus, { infer: true, ignoreCM: true }));
+			// For a trash push, we must assume the focus is playable by our turn - no need to look for self connections.
+			if (focus_interp !== FOCUS_INTERP.TRASH_PUSH) {
+				for (const id of common.thoughts[focus].inferred) {
+					if (isTrash(state, game.players[giver], id, focus, { infer: true, ignoreCM: true }) ||
+						(clue.type === CLUE.RANK && state.includesVariant(variantRegexes.pinkish) && id.rank !== clue.value) ||		// Pink promise
+						all_connections.some(fp => id.matches(fp)))					// Focus possibility, skip
+						continue;
 
-			for (const id of common.thoughts[focus].inferred) {
-				if (isTrash(state, game.players[giver], id, focus, { infer: true, ignoreCM: true }) ||
-					(clue.type === CLUE.RANK && state.includesVariant(variantRegexes.pinkish) && id.rank !== clue.value) ||		// Pink promise
-					all_connections.some(fp => id.matches(fp)))					// Focus possibility, skip
-					continue;
+					try {
+						const connections = find_own_finesses(game, action, focus, id, looksDirect);
+						logger.info('found connections:', logConnections(connections, id));
 
-				try {
-					const connections = find_own_finesses(game, action, focus, id, looksDirect);
-					logger.info('found connections:', logConnections(connections, id));
+						const rank = inference_rank(state, id.suitIndex, connections);
 
-					const rank = inference_rank(state, id.suitIndex, connections);
+						let same_match = false;
 
-					let same_match = false;
+						for (const fp of all_connections) {
+							for (const conn of connections) {
+								if (conn.type !== 'known' || conn.reacting !== giver || !conn.identities.every(i => i.rank === fp.rank && i.suitIndex === fp.suitIndex))
+									continue;
 
-					for (const fp of all_connections) {
-						for (const conn of connections) {
-							if (conn.type !== 'known' || conn.reacting !== giver || !conn.identities.every(i => i.rank === fp.rank && i.suitIndex === fp.suitIndex))
-								continue;
+								same_match = true;
 
-							same_match = true;
-
-							// Valid asymmetric clue (or we at least have to entertain it)
-							if (game.players[giver].thoughts[conn.order].inferred.every(i =>
-								i.matches(fp) || (state.isCritical(i) && i.matches({ suitIndex: id.suitIndex, rank })))) {
-								same_match = false;
-								conn.asymmetric = false;
-								break;
+								// Valid asymmetric clue (or we at least have to entertain it)
+								if (game.players[giver].thoughts[conn.order].inferred.every(i =>
+									i.matches(fp) || (state.isCritical(i) && i.matches({ suitIndex: id.suitIndex, rank })))) {
+									same_match = false;
+									conn.asymmetric = false;
+									break;
+								}
 							}
 						}
-					}
 
-					if (same_match) {
-						logger.warn(`attempted to use giver's known connecting when focus could be it!`);
-						continue;
-					}
+						if (same_match) {
+							logger.warn(`attempted to use giver's known connecting when focus could be it!`);
+							continue;
+						}
 
-					all_connections.push({ connections, suitIndex: id.suitIndex, rank, interp: CLUE_INTERP.PLAY });
+						all_connections.push({ connections, suitIndex: id.suitIndex, rank, interp: CLUE_INTERP.PLAY });
 
-					// Consider possible intermediate bluff connections.
-					if (game.level >= LEVEL.INTERMEDIATE_BLUFFS && connections.length > 0 && connections[0].type === 'finesse' && (connections[0].possibly_bluff || connections[0].bluff) && is_intermediate_bluff_target(game, action, id, focus)) {
-						const order = connections[0].order;
-						all_connections.push({
-							connections: [{...connections[0], bluff: true, possibly_bluff: false,
-								identities: get_bluffable_ids(game, action, game.common.thoughts[order].inferred, [focus], connections[0].reacting)}],
-							suitIndex: id.suitIndex, rank: id.rank, interp: CLUE_INTERP.PLAY });
-						logger.info('found bluff connections:', logConnections(all_connections.at(-1).connections, id));
+						// Consider possible intermediate bluff connections.
+						if (game.level >= LEVEL.INTERMEDIATE_BLUFFS && connections.length > 0 && connections[0].type === 'finesse' && (connections[0].possibly_bluff || connections[0].bluff) && is_intermediate_bluff_target(game, action, id, focus)) {
+							const order = connections[0].order;
+							all_connections.push({
+								connections: [{...connections[0], bluff: true, possibly_bluff: false,
+									identities: get_bluffable_ids(game, action, game.common.thoughts[order].inferred, [focus], connections[0].reacting)}],
+								suitIndex: id.suitIndex, rank: id.rank, interp: CLUE_INTERP.PLAY });
+							logger.info('found bluff connections:', logConnections(all_connections.at(-1).connections, id));
+						}
 					}
-				}
-				catch (error) {
-					if (error instanceof IllegalInterpretation)
-						logger.warn(error.message);
-					else
-						throw error;
+					catch (error) {
+						if (error instanceof IllegalInterpretation)
+							logger.warn(error.message);
+						else
+							throw error;
+					}
 				}
 			}
 

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -687,7 +687,7 @@ export function interpret_clue(game, action) {
 
 	const focus_possible = find_focus_possible(game, action, focusResult, thinks_stall, loaded, focus_interp);
 	logger.info('focus possible:', focus_possible.map(({ suitIndex, rank, save, illegal }) => logCard({suitIndex, rank}) + (save ? ' (save)' : ''  + (illegal ? ' (illegal)' : ''))));
-	const trash_finesses = focus_possible.filter(p => state.isBasicTrash(p));
+	const trash_finesses = focus_possible.filter(p => p.interp === CLUE_INTERP.TRASH_FINESSE);
 	if (trash_finesses.length > 0 && (target === state.ourPlayerIndex || !focus_possible.some(p => !p.illegal && common.thoughts[focus].inferred.has(p) &&focused_card.matches(p)))) {
 		// If a trash finesse is possible, we must assume one
 		// if possible unless / until the finessed card is not playable.
@@ -702,6 +702,14 @@ export function interpret_clue(game, action) {
 			// Trash chop move
 			const tcm_orders = interpret_tcm(game, action, focus, oldCommon, true);
 			perform_cm(state, common, tcm_orders);
+		}
+
+		// Further, any play identites are illegal if they could also be trash finesse identites:
+		for (const fp of focus_possible.filter(p => p.interp === CLUE_INTERP.PLAY)) {
+			if (trash_finesses.some(tf => tf.suitIndex === fp.suitIndex && tf.rank === fp.rank)) {
+				fp.illegal = true;
+				logger.info(`marking ${logCard(fp)} as illegal due to possible trash finesse identity`);
+			}
 		}
 	}
 

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -945,8 +945,7 @@ export function interpret_clue(game, action) {
 								}
 								// We need to play at least 1 card, but can stop when there is one or zero
 								// instances of useful identity left as we may have it visible in our hand.
-								max_rank = Math.min(max_rank,
-									Math.max(state.play_stacks[suitIndex] + 1, useful_at_rank_or_higher.findIndex(count => count <= 1)));
+								max_rank = Math.min(max_rank, useful_at_rank_or_higher.findIndex(count => count <= 1));
 							}
 							if (state.play_stacks[suitIndex] >= max_rank)
 								continue;

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -7,7 +7,7 @@ import { stalling_situation } from './interpret-stall.js';
 import { determine_focus, getRealConnects, rankLooksPlayable, unknown_1 } from '../hanabi-logic.js';
 import { find_focus_possible } from './focus-possible.js';
 import { IllegalInterpretation, find_own_finesses, find_own_trash_finesses } from './own-finesses.js';
-import { assign_all_connections, inference_rank, find_symmetric_connections, generate_symmetric_connections, occams_razor, connection_score, is_intermediate_bluff_target, get_bluffable_ids, is_trash_finesse_target } from './connection-helper.js';
+import { assign_all_connections, inference_rank, find_symmetric_connections, generate_symmetric_connections, occams_razor, connection_score, is_intermediate_bluff_target, get_bluffable_ids, is_trash_finesse_target, find_trash_finesses } from './connection-helper.js';
 import { variantRegexes } from '../../../variants.js';
 import { remove_finesse } from '../update-wcs.js';
 import { order_1s } from '../action-helper.js';
@@ -940,15 +940,13 @@ export function interpret_clue(game, action) {
 							const connections = find_own_trash_finesses(game, action, focus, new BasicCard(suitIndex, max_rank));
 							if (connections === undefined)
 								continue;
+							const trash_connections = find_trash_finesses(game, action, focus, connections, suitIndex);
+							if (trash_connections.length === 0)
+								continue;
 
-							logger.info('found connections:', logConnections(connections, focused_card));
-							for (const id of trash_ids) {
-								all_connections.push({
-									...id,
-									connections,
-									interp: CLUE_INTERP.TRASH_FINESSE,
-								});
-							}
+							logger.info('found connections:', logConnections(trash_connections[0].connections, focused_card));
+							for (const fp of trash_connections)
+								all_connections.push(fp);
 						}
 					}
 					simplest_connections = occams_razor(game, all_connections, state.ourPlayerIndex, focus);

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -465,6 +465,9 @@ export function interpret_clue(game, action) {
 	if (rewinded)
 		return game;
 
+	if (focus_interp === FOCUS_INTERP.TRASH_PUSH)
+		common.updateThoughts(focus, (draft) => { draft.assume_playable = true; });
+
 	if (focus_interp !== FOCUS_INTERP.TRASH_PUSH && chop && !action.noRecurse) {
 		common.updateThoughts(focus, (draft) => { draft.chop_when_first_clued = true; });
 		action.important = !loaded && urgent_save(game, action, focus, oldCommon, prev_game);

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -143,10 +143,6 @@ function resolve_clue(game, old_game, action, focusResult, simplest_poss, all_po
 	// TODO: Maybe we should not rule them out in the first place?
 	const trash_fps = simplest_poss.filter(sp => sp.interp == CLUE_INTERP.TRASH_FINESSE);
 	if (trash_fps.length > 0) {
-		old_game.common.updateThoughts(focus, (draft) => {
-			draft.inferred = common.thoughts[focus].inferred.union(trash_fps);
-			draft.trash = true;
-		});
 		common.updateThoughts(focus, (draft) => {
 			draft.inferred = common.thoughts[focus].inferred.union(trash_fps);
 			draft.trash = true;
@@ -715,11 +711,13 @@ export function interpret_clue(game, action) {
 
 	const focus_possible = find_focus_possible(game, action, focusResult, thinks_stall, loaded, focus_interp);
 	logger.info('focus possible:', focus_possible.map(({ suitIndex, rank, save, illegal }) => logCard({suitIndex, rank}) + (save ? ' (save)' : ''  + (illegal ? ' (illegal)' : ''))));
-	const trash_finesses = focus_possible.filter(p => p.interp === CLUE_INTERP.TRASH_FINESSE);
-	if (trash_finesses.length > 0 && (target === state.ourPlayerIndex || !focus_possible.some(p => !p.illegal && common.thoughts[focus].inferred.has(p) &&focused_card.matches(p)))) {
+	const consider_trash = focus_possible.some(p => p.interp === CLUE_INTERP.TRASH_FINESSE) &&
+		(target === state.ourPlayerIndex ||
+			!focus_possible.some(p => !p.illegal && common.thoughts[focus].inferred.has(p) && focused_card.matches(p)));
+	if (consider_trash) {
+		const trash_finesses = focus_possible.filter(p => p.interp === CLUE_INTERP.TRASH_FINESSE);
 		// If a trash finesse is possible, we must assume one
 		// if possible unless / until the finessed card is not playable.
-		// Trash chop move
 		const tcm_orders = interpret_tcm(game, action, focus, oldCommon, true);
 		perform_cm(state, common, tcm_orders);
 
@@ -732,7 +730,9 @@ export function interpret_clue(game, action) {
 		}
 	}
 
-	const matched_inferences = focus_possible.filter(p => !p.illegal && (common.thoughts[focus].inferred.has(p) || p.interp === CLUE_INTERP.TRASH_FINESSE));
+	const matched_inferences = focus_possible.filter(p => !p.illegal && (
+		common.thoughts[focus].inferred.has(p) ||
+		consider_trash && common.thoughts[focus].possible.has(p) && p.interp === CLUE_INTERP.TRASH_FINESSE));
 	const old_game = game.minimalCopy();
 
 	// Card matches an inference and not a save/stall

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -151,6 +151,18 @@ function resolve_clue(game, old_game, action, focusResult, simplest_poss, all_po
 			draft.inferred = common.thoughts[focus].inferred.union(trash_fps);
 			draft.trash = true;
 		});
+		// All newly clued cards are trash
+		for (const order of state.hands[target]) {
+			if (order === focus || !state.deck[order].newly_clued)
+				continue;
+
+			const { possible } = common.thoughts[order];
+			const new_inferred = possible.intersect(possible.filter(i => state.isBasicTrash(i)));
+			common.updateThoughts(order, (draft) => {
+				draft.inferred = new_inferred;
+				draft.trash = true;
+			});
+		}
 	}
 
 	common.updateThoughts(focus, (draft) => {

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -21,7 +21,6 @@ import * as Utils from '../../../tools/util.js';
 import logger from '../../../tools/logger.js';
 import { logCard, logConnection, logConnections, logHand } from '../../../tools/log.js';
 import { produce } from '../../../StateProxy.js';
-import { join } from 'path';
 
 /**
  * @typedef {import('../../h-group.js').default} Game
@@ -470,7 +469,8 @@ export function interpret_clue(game, action) {
 
 	let focus_interp = FOCUS_INTERP.NORMAL;
 	const focusResult = determine_focus(game, state.hands[target], common, list, clue);
-	let { focus, chop, positional } = focusResult;
+	const { positional } = focusResult;
+	let { focus, chop } = focusResult;
 	let focused_card = state.deck[focus];
 
 	common.updateThoughts(focus, (draft) => { draft.focused = true; });

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -1,12 +1,12 @@
 import { CLUE } from '../../../constants.js';
 import { CLUE_INTERP, FOCUS_INTERP, LEVEL } from '../h-constants.js';
-import { CARD_STATUS } from '../../../basics/Card.js';
+import { BasicCard, CARD_STATUS } from '../../../basics/Card.js';
 import { IdentitySet } from '../../../basics/IdentitySet.js';
 import { interpret_tcm, interpret_5cm, interpret_tccm, perform_cm } from './interpret-cm.js';
 import { stalling_situation } from './interpret-stall.js';
 import { determine_focus, getRealConnects, rankLooksPlayable, unknown_1 } from '../hanabi-logic.js';
 import { find_focus_possible } from './focus-possible.js';
-import { IllegalInterpretation, find_own_finesses } from './own-finesses.js';
+import { IllegalInterpretation, find_own_finesses, find_own_trash_finesses } from './own-finesses.js';
 import { assign_all_connections, inference_rank, find_symmetric_connections, generate_symmetric_connections, occams_razor, connection_score, is_intermediate_bluff_target, get_bluffable_ids } from './connection-helper.js';
 import { variantRegexes } from '../../../variants.js';
 import { remove_finesse } from '../update-wcs.js';
@@ -139,7 +139,9 @@ function resolve_clue(game, old_game, action, focusResult, simplest_poss, all_po
 	const focus = focused_card.order;
 	const old_inferred = old_game.common.thoughts[focus].inferred;
 
-	common.updateThoughts(focus, (draft) => { draft.inferred = common.thoughts[focus].inferred.intersect(simplest_poss); });
+	common.updateThoughts(focus, (draft) => {
+		draft.inferred = common.thoughts[focus].inferred.intersect(simplest_poss).union(simplest_poss.filter(sp => sp.interp == CLUE_INTERP.TRASH_FINESSE));
+	});
 
 	if (important_finesse(state, action, simplest_poss)) {
 		logger.highlight('yellow', 'action is important!');
@@ -870,6 +872,64 @@ export function interpret_clue(game, action) {
 					throw error;
 			}
 			simplest_connections = all_connections;
+		// Someone else is the clue target, and might think it's playable.
+		// Consider possible trash bluffs or finesses on us.
+		} else if (game.level >= LEVEL.TRASH_MOVES && giver !== state.ourPlayerIndex && state.isBasicTrash(focused_card) && common.thoughts[focus].possible.some(id => !state.isBasicTrash(id))) {
+			const own_finesse = common.find_finesse(state, state.ourPlayerIndex, [], []);
+			if (own_finesse !== undefined) {
+				const trash_ids = common.thoughts[focus].possible.filter(id => state.isBasicTrash(id));
+				// In order to demonstrate a trash bluff, there needs to be no playable identities
+				// if the card is not immediately playable.
+				const possible_bluff = state.nextPlayerIndex(giver) === state.ourPlayerIndex &&
+					!common.thoughts[focus].possible.some(id => !state.isBasicTrash(id) && !state.isPlayable(id));
+				if (possible_bluff) {
+					// We only need to consider any immediately playable card.
+					const bluffable_ids = common.thoughts[own_finesse].possible.filter(id => state.isPlayable(id));
+					if (bluffable_ids.length > 0) {
+						for (const id of trash_ids) {
+							all_connections.push({
+								...id,
+								connections: [{type: 'finesse', reacting: state.ourPlayerIndex, order: own_finesse, identities: bluffable_ids, bluff: true}],
+								interp: CLUE_INTERP.TRASH_FINESSE,
+							});
+						}
+						logger.info('found connections:', logConnections(all_connections.at(-1).connections, trash_ids));
+					}
+				} else {
+					const suits = action.clue.type === CLUE.COLOUR ? [action.clue.value] : state.variant.suits.map((_, i) => i);
+					for (const suitIndex of suits) {
+						// We need to play up to the highest playable rank the target might think they have.
+						let max_rank = 0;
+						if (action.clue.type === CLUE.RANK) {
+							max_rank = action.clue.value;
+						} else {
+							for (const id of common.thoughts[focus].possible.filter(id => id.suitIndex === suitIndex && !state.isBasicTrash(id))) {
+								if (id.rank > max_rank)
+									max_rank = id.rank;
+							}
+						}
+						if (state.play_stacks[suitIndex] >= max_rank)
+							continue;
+						const connections = find_own_trash_finesses(game, action, focus, new BasicCard(suitIndex, max_rank));
+						if (connections === undefined)
+							continue;
+
+						logger.info('found connections:', logConnections(connections, focused_card));
+						for (const id of trash_ids) {
+							all_connections.push({
+								...id,
+								connections,
+								interp: CLUE_INTERP.TRASH_FINESSE,
+							});
+						}
+					}
+				}
+				simplest_connections = occams_razor(game, all_connections, state.ourPlayerIndex, focus);
+				if (all_connections.length > 0) {
+					const tcm_orders = interpret_tcm(game, action, focus, oldCommon, true);
+					perform_cm(state, common, tcm_orders);
+				}
+			}
 		}
 
 		const finalized_connections = finalize_connections(state, action, simplest_connections);

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -916,22 +916,31 @@ export function interpret_clue(game, action) {
 					} else {
 						const suits = action.clue.type === CLUE.COLOUR ? [action.clue.value] : state.variant.suits.map((_, i) => i);
 						for (const suitIndex of suits) {
-							// We need to play up to the highest playable rank the target might think they have.
+							// We need to play at least until there is only one possibility left (through trash touch elimination)
 							let max_rank = 0;
 							if (action.clue.type === CLUE.RANK) {
 								max_rank = action.clue.value;
 							} else {
+								// 6 "rank" array to ensure we always find a rank with no playables
+								const playables_at_rank_or_higher = [0, 0, 0, 0, 0, 0];
 								for (const id of common.thoughts[focus].possible.filter(id => id.suitIndex === suitIndex && !state.isBasicTrash(id))) {
-									if (id.rank > max_rank)
-										max_rank = id.rank;
+									max_rank = Math.max(id.rank, max_rank);
+									const remaining = state.cardCount(id) - state.discard_stacks[id.suitIndex][id.rank - 1];
+									for (let r = 1; r <= id.rank; ++r)
+										playables_at_rank_or_higher[r - 1] += remaining;
 								}
+								// We need to play at least 1 card, but can stop when there is one or fewer
+								// playable instances of the identity left as we may have it visible in our hand.
+								max_rank = Math.min(max_rank,
+									Math.max(state.play_stacks[suitIndex] + 1, playables_at_rank_or_higher.findIndex(count => count <= 1)));
 							}
 							if (state.play_stacks[suitIndex] >= max_rank)
 								continue;
-							const connections = find_own_trash_finesses(game, action, focus, new BasicCard(suitIndex, max_rank));
+							const max_id = new BasicCard(suitIndex, max_rank);
+							const connections = find_own_trash_finesses(game, action, focus, max_id);
 							if (connections === undefined)
 								continue;
-							const trash_connections = find_trash_finesses(game, action, focus, connections, suitIndex);
+							const trash_connections = find_trash_finesses(game, action, focus, connections, max_id);
 							if (trash_connections.length === 0)
 								continue;
 

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -739,6 +739,23 @@ export function interpret_clue(game, action) {
 
 	const focus_possible = find_focus_possible(game, action, focusResult, thinks_stall, loaded, focus_interp);
 	logger.info('focus possible:', focus_possible.map(({ suitIndex, rank, save, illegal }) => logCard({suitIndex, rank}) + (save ? ' (save)' : ''  + (illegal ? ' (illegal)' : ''))));
+	const trash_finesses = focus_possible.filter(p => state.isBasicTrash(p));
+	if (trash_finesses.length > 0 && (target === state.ourPlayerIndex || !focus_possible.some(p => !p.illegal && common.thoughts[focus].inferred.has(p) &&focused_card.matches(p)))) {
+		// If a trash finesse is possible, we must assume one
+		// if possible unless / until the finessed card is not playable.
+		const { possible } = common.thoughts[focus];
+		const new_inferred = possible.intersect(trash_finesses);
+		if (new_inferred.length > 0) {
+			common.updateThoughts(focus, (draft) => {
+				draft.inferred = new_inferred;
+				draft.info_lock = new_inferred;
+				draft.trash = true;
+			});
+			// Trash chop move
+			const tcm_orders = interpret_tcm(game, action, focus, oldCommon, true);
+			perform_cm(state, common, tcm_orders);
+		}
+	}
 
 	const matched_inferences = focus_possible.filter(p => !p.illegal && common.thoughts[focus].inferred.has(p));
 	const old_game = game.minimalCopy();
@@ -784,7 +801,7 @@ export function interpret_clue(game, action) {
 		// We are the clue target, so we need to consider all the (sensible) possibilities of the card
 		if (target === state.ourPlayerIndex) {
 			all_connections = focus_possible.filter(fp =>
-				!isTrash(prev_game.state, prev_game.players[giver], fp, focus, { infer: true, ignoreCM: true }));
+				fp.interp === CLUE_INTERP.TRASH_FINESSE || !isTrash(prev_game.state, prev_game.players[giver], fp, focus, { infer: true, ignoreCM: true }));
 
 			for (const id of common.thoughts[focus].inferred) {
 				if (isTrash(state, game.players[giver], id, focus, { infer: true, ignoreCM: true }) ||

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -935,18 +935,18 @@ export function interpret_clue(game, action) {
 							if (action.clue.type === CLUE.RANK) {
 								max_rank = action.clue.value;
 							} else {
-								// 6 "rank" array to ensure we always find a rank with no playables
-								const playables_at_rank_or_higher = [0, 0, 0, 0, 0, 0];
+								// 6 "rank" array to ensure we always find a rank with no useful cards left.
+								const useful_at_rank_or_higher = [0, 0, 0, 0, 0, 0];
 								for (const id of common.thoughts[focus].possible.filter(id => id.suitIndex === suitIndex && !state.isBasicTrash(id))) {
 									max_rank = Math.max(id.rank, max_rank);
 									const remaining = state.cardCount(id) - state.discard_stacks[id.suitIndex][id.rank - 1];
 									for (let r = 1; r <= id.rank; ++r)
-										playables_at_rank_or_higher[r - 1] += remaining;
+										useful_at_rank_or_higher[r - 1] += remaining;
 								}
-								// We need to play at least 1 card, but can stop when there is one or fewer
-								// playable instances of the identity left as we may have it visible in our hand.
+								// We need to play at least 1 card, but can stop when there is one or zero
+								// instances of useful identity left as we may have it visible in our hand.
 								max_rank = Math.min(max_rank,
-									Math.max(state.play_stacks[suitIndex] + 1, playables_at_rank_or_higher.findIndex(count => count <= 1)));
+									Math.max(state.play_stacks[suitIndex] + 1, useful_at_rank_or_higher.findIndex(count => count <= 1)));
 							}
 							if (state.play_stacks[suitIndex] >= max_rank)
 								continue;

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -7,7 +7,7 @@ import { stalling_situation } from './interpret-stall.js';
 import { determine_focus, getRealConnects, rankLooksPlayable, unknown_1 } from '../hanabi-logic.js';
 import { find_focus_possible } from './focus-possible.js';
 import { IllegalInterpretation, find_own_finesses, find_own_trash_finesses } from './own-finesses.js';
-import { assign_all_connections, inference_rank, find_symmetric_connections, generate_symmetric_connections, occams_razor, connection_score, is_intermediate_bluff_target, get_bluffable_ids } from './connection-helper.js';
+import { assign_all_connections, inference_rank, find_symmetric_connections, generate_symmetric_connections, occams_razor, connection_score, is_intermediate_bluff_target, get_bluffable_ids, is_trash_finesse_target } from './connection-helper.js';
 import { variantRegexes } from '../../../variants.js';
 import { remove_finesse } from '../update-wcs.js';
 import { order_1s } from '../action-helper.js';
@@ -901,60 +901,67 @@ export function interpret_clue(game, action) {
 		// Someone else is the clue target, and might think it's playable.
 		// Consider possible trash bluffs or finesses on us.
 		} else if (game.level >= LEVEL.TRASH_MOVES && giver !== state.ourPlayerIndex && state.isBasicTrash(focused_card) && common.thoughts[focus].possible.some(id => !state.isBasicTrash(id))) {
-			const own_finesse = common.find_finesse(state, state.ourPlayerIndex, [], []);
-			if (own_finesse !== undefined) {
-				const trash_ids = common.thoughts[focus].possible.filter(id => state.isBasicTrash(id));
-				// In order to demonstrate a trash bluff, there needs to be no playable identities
-				// if the card is not immediately playable.
-				const possible_bluff = state.nextPlayerIndex(giver) === state.ourPlayerIndex &&
-					!common.thoughts[focus].possible.some(id => !state.isBasicTrash(id) && !state.isPlayable(id));
-				if (possible_bluff) {
-					// We only need to consider any immediately playable card.
-					const bluffable_ids = common.thoughts[own_finesse].possible.filter(id => state.isPlayable(id));
-					if (bluffable_ids.length > 0) {
-						for (const id of trash_ids) {
-							all_connections.push({
-								...id,
-								connections: [{type: 'finesse', reacting: state.ourPlayerIndex, order: own_finesse, identities: bluffable_ids, bluff: true}],
-								interp: CLUE_INTERP.TRASH_FINESSE,
-							});
+			if (is_trash_finesse_target(game, focus)) {
+				const own_finesse = common.find_finesse(state, state.ourPlayerIndex, [], []);
+				if (own_finesse !== undefined) {
+					const trash_ids = common.thoughts[focus].possible.filter(id => state.isBasicTrash(id));
+					// In order to demonstrate a trash bluff, there needs to be no playable identities
+					// if the card is not immediately playable.
+					const possible_bluff = state.nextPlayerIndex(giver) === state.ourPlayerIndex &&
+						!common.thoughts[focus].possible.some(id => !state.isBasicTrash(id) && !state.isPlayable(id));
+					if (possible_bluff) {
+						// We only need to consider any immediately playable card.
+						const bluffable_ids = common.thoughts[own_finesse].possible.filter(id => state.isPlayable(id));
+						if (bluffable_ids.length > 0) {
+							for (const id of trash_ids) {
+								all_connections.push({
+									...id,
+									connections: [{type: 'finesse', reacting: state.ourPlayerIndex, order: own_finesse, identities: bluffable_ids, bluff: true}],
+									interp: CLUE_INTERP.TRASH_FINESSE,
+								});
+							}
+							logger.info('found connections:', logConnections(all_connections.at(-1).connections, trash_ids));
 						}
-						logger.info('found connections:', logConnections(all_connections.at(-1).connections, trash_ids));
-					}
-				} else {
-					const suits = action.clue.type === CLUE.COLOUR ? [action.clue.value] : state.variant.suits.map((_, i) => i);
-					for (const suitIndex of suits) {
-						// We need to play up to the highest playable rank the target might think they have.
-						let max_rank = 0;
-						if (action.clue.type === CLUE.RANK) {
-							max_rank = action.clue.value;
-						} else {
-							for (const id of common.thoughts[focus].possible.filter(id => id.suitIndex === suitIndex && !state.isBasicTrash(id))) {
-								if (id.rank > max_rank)
-									max_rank = id.rank;
+					} else {
+						const suits = action.clue.type === CLUE.COLOUR ? [action.clue.value] : state.variant.suits.map((_, i) => i);
+						for (const suitIndex of suits) {
+							// We need to play up to the highest playable rank the target might think they have.
+							let max_rank = 0;
+							if (action.clue.type === CLUE.RANK) {
+								max_rank = action.clue.value;
+							} else {
+								for (const id of common.thoughts[focus].possible.filter(id => id.suitIndex === suitIndex && !state.isBasicTrash(id))) {
+									if (id.rank > max_rank)
+										max_rank = id.rank;
+								}
+							}
+							if (state.play_stacks[suitIndex] >= max_rank)
+								continue;
+							const connections = find_own_trash_finesses(game, action, focus, new BasicCard(suitIndex, max_rank));
+							if (connections === undefined)
+								continue;
+
+							logger.info('found connections:', logConnections(connections, focused_card));
+							for (const id of trash_ids) {
+								all_connections.push({
+									...id,
+									connections,
+									interp: CLUE_INTERP.TRASH_FINESSE,
+								});
 							}
 						}
-						if (state.play_stacks[suitIndex] >= max_rank)
-							continue;
-						const connections = find_own_trash_finesses(game, action, focus, new BasicCard(suitIndex, max_rank));
-						if (connections === undefined)
-							continue;
-
-						logger.info('found connections:', logConnections(connections, focused_card));
-						for (const id of trash_ids) {
-							all_connections.push({
-								...id,
-								connections,
-								interp: CLUE_INTERP.TRASH_FINESSE,
-							});
-						}
+					}
+					simplest_connections = occams_razor(game, all_connections, state.ourPlayerIndex, focus);
+					if (all_connections.length > 0) {
+						const tcm_orders = interpret_tcm(game, action, focus, oldCommon, true);
+						perform_cm(state, common, tcm_orders);
 					}
 				}
-				simplest_connections = occams_razor(game, all_connections, state.ourPlayerIndex, focus);
-				if (all_connections.length > 0) {
-					const tcm_orders = interpret_tcm(game, action, focus, oldCommon, true);
-					perform_cm(state, common, tcm_orders);
-				}
+			} else {
+				// If the target is not a valid trash finesse target, we should still interpret
+				// it as a trash chop move as we likely have the matching identity.
+				const tcm_orders = interpret_tcm(game, action, focus, oldCommon, true);
+				perform_cm(state, common, tcm_orders);
 			}
 		}
 

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -2,12 +2,12 @@ import { CLUE } from '../../../constants.js';
 import { CLUE_INTERP, FOCUS_INTERP, LEVEL } from '../h-constants.js';
 import { BasicCard, CARD_STATUS } from '../../../basics/Card.js';
 import { IdentitySet } from '../../../basics/IdentitySet.js';
-import { interpret_tcm, interpret_5cm, interpret_tccm, perform_cm } from './interpret-cm.js';
+import { interpret_tcm, interpret_5cm, interpret_tccm, perform_cm, is_trash_clue } from './interpret-cm.js';
 import { stalling_situation } from './interpret-stall.js';
 import { determine_focus, getRealConnects, rankLooksPlayable, unknown_1 } from '../hanabi-logic.js';
 import { find_focus_possible } from './focus-possible.js';
 import { IllegalInterpretation, find_own_finesses, find_own_trash_finesses } from './own-finesses.js';
-import { assign_all_connections, inference_rank, find_symmetric_connections, generate_symmetric_connections, occams_razor, connection_score, is_intermediate_bluff_target, get_bluffable_ids, is_trash_finesse_target, find_trash_finesses } from './connection-helper.js';
+import { assign_all_connections, inference_rank, find_symmetric_connections, generate_symmetric_connections, occams_razor, connection_score, is_intermediate_bluff_target, get_bluffable_ids, find_trash_finesses } from './connection-helper.js';
 import { variantRegexes } from '../../../variants.js';
 import { remove_finesse } from '../update-wcs.js';
 import { order_1s } from '../action-helper.js';
@@ -892,7 +892,7 @@ export function interpret_clue(game, action) {
 		// Someone else is the clue target, and might think it's playable.
 		// Consider possible trash bluffs or finesses on us.
 		} else if (game.level >= LEVEL.TRASH_MOVES && giver !== state.ourPlayerIndex && state.isBasicTrash(focused_card) && common.thoughts[focus].possible.some(id => !state.isBasicTrash(id))) {
-			if (is_trash_finesse_target(game, focus)) {
+			if (!is_trash_clue(game, giver, clue, target, focus, oldCommon)) {
 				const own_finesse = common.find_finesse(state, state.ourPlayerIndex, [], []);
 				if (own_finesse !== undefined) {
 					const trash_ids = common.thoughts[focus].possible.filter(id => state.isBasicTrash(id));

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -139,8 +139,22 @@ function resolve_clue(game, old_game, action, focusResult, simplest_poss, all_po
 	const focus = focused_card.order;
 	const old_inferred = old_game.common.thoughts[focus].inferred;
 
+	// Trash finesse possibilities need to be re-added as trash is normally ruled out.
+	// TODO: Maybe we should not rule them out in the first place?
+	const trash_fps = simplest_poss.filter(sp => sp.interp == CLUE_INTERP.TRASH_FINESSE);
+	if (trash_fps.length > 0) {
+		old_game.common.updateThoughts(focus, (draft) => {
+			draft.inferred = common.thoughts[focus].inferred.union(trash_fps);
+			draft.trash = true;
+		});
+		common.updateThoughts(focus, (draft) => {
+			draft.inferred = common.thoughts[focus].inferred.union(trash_fps);
+			draft.trash = true;
+		});
+	}
+
 	common.updateThoughts(focus, (draft) => {
-		draft.inferred = common.thoughts[focus].inferred.intersect(simplest_poss).union(simplest_poss.filter(sp => sp.interp == CLUE_INTERP.TRASH_FINESSE));
+		draft.inferred = common.thoughts[focus].inferred.intersect(simplest_poss);
 	});
 
 	if (important_finesse(state, action, simplest_poss)) {

--- a/src/conventions/h-group/clue-interpretation/interpret-clue.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-clue.js
@@ -1,5 +1,5 @@
 import { CLUE } from '../../../constants.js';
-import { CLUE_INTERP, LEVEL } from '../h-constants.js';
+import { CLUE_INTERP, FOCUS_INTERP, LEVEL } from '../h-constants.js';
 import { CARD_STATUS } from '../../../basics/Card.js';
 import { IdentitySet } from '../../../basics/IdentitySet.js';
 import { interpret_tcm, interpret_5cm, interpret_tccm, perform_cm } from './interpret-cm.js';
@@ -21,6 +21,7 @@ import * as Utils from '../../../tools/util.js';
 import logger from '../../../tools/logger.js';
 import { logCard, logConnection, logConnections, logHand } from '../../../tools/log.js';
 import { produce } from '../../../StateProxy.js';
+import { join } from 'path';
 
 /**
  * @typedef {import('../../h-group.js').default} Game
@@ -230,6 +231,8 @@ function resolve_clue(game, old_game, action, focusResult, simplest_poss, all_po
 		common.thoughts.splice(old_chop, 1, produce(common.thoughts[old_chop], (draft) => { draft.status = undefined; }));
 
 		logger.highlight('yellow', `undoing scream discard chop move on ${old_chop} due to generation!`);
+	} else if (interp === CLUE_INTERP.PLAY && !action.list.includes(focus)) {
+		common.updateThoughts(focus, (draft) => { draft.status = CARD_STATUS.FINESSED; });
 	}
 
 	common.updateThoughts(focus, (draft) => { draft.info_lock = draft.inferred.clone(); });
@@ -365,6 +368,43 @@ function try_tccm(game, oldCommon, stall, thinks_stall, target, list, focused_ca
 	}
 }
 
+
+/**
+ * Checks whether a Trash Push was performed on the target. The clue must have already been registered.
+ * @param {Game} game
+ * @param {ClueAction} action
+ * @param {number} focus_order
+ * @param {Player} oldCommon
+ * @returns The order of the trash pushed card.
+ */
+export function interpret_tp(game, action, focus_order, oldCommon) {
+	const { common, state } = game;
+	const { clue, target } = action;
+	const focused_card = state.deck[focus_order];
+	const focus_thoughts = common.thoughts[focus_order];
+
+	// A trash push must not save any cards - i.e. must target the chop,
+	// and there must be a card to push.
+	const chop = common.chop(state.hands[target]);
+	if (chop === undefined || !focused_card.newly_clued || !focus_thoughts.chop_when_first_clued)
+		return undefined;
+
+	if (clue.type === CLUE.RANK) {
+		const promised_ids = Utils.range(0, state.variant.suits.length).map(suitIndex => ({ suitIndex, rank: clue.value }));
+
+		if (focus_thoughts.possible.intersect(promised_ids).some(i => !isTrash(state, oldCommon, i, focus_order, { infer: true })))
+			return undefined;
+	}
+	else if (focus_thoughts.possible.some(c => !isTrash(state, oldCommon, c, focus_order, { infer: true })) ||
+		focus_thoughts.inferred.every(i => state.isPlayable(i) && !isTrash(state, oldCommon, i, focus_order, { infer: true }))) {
+		return undefined;
+	}
+
+	logger.highlight('cyan', `trash push on ${logCard(state.deck[chop])} ${chop}`);
+
+	return chop;
+}
+
 /**
  * Interprets the given clue. First tries to look for inferred connecting cards, then attempts to find prompts/finesses.
  * 
@@ -427,9 +467,11 @@ export function interpret_clue(game, action) {
 	const loaded = common.thinksTrash(state, target).length > 0 || connectable_simple(game, state.nextPlayerIndex(giver), target);
 	logger.info('loaded?', loaded);
 
+
+	let focus_interp = FOCUS_INTERP.NORMAL;
 	const focusResult = determine_focus(game, state.hands[target], common, list, clue);
-	const { focus, chop, positional } = focusResult;
-	const focused_card = state.deck[focus];
+	let { focus, chop, positional } = focusResult;
+	let focused_card = state.deck[focus];
 
 	common.updateThoughts(focus, (draft) => { draft.focused = true; });
 	const { fix, rewinded } = apply_good_touch(game, action, oldCommon.thoughts);
@@ -682,7 +724,20 @@ export function interpret_clue(game, action) {
 		return game;
 	}
 
-	const focus_possible = find_focus_possible(game, action, focusResult, thinks_stall, loaded);
+	// Focus adjusting conventions occur just before resolving focus possibilities.
+	if (game.level >= LEVEL.TRASH_MOVES) {
+		const tp = interpret_tp(game, action, focus, oldCommon);
+
+		if (tp !== undefined) {
+			logger.info('trash push, new focus:', tp);
+			focusResult.focus = focus = tp;
+			focusResult.chop = chop = false;
+			focus_interp = FOCUS_INTERP.TRASH_PUSH;
+			focused_card = state.deck[focus];
+		}
+	}
+
+	const focus_possible = find_focus_possible(game, action, focusResult, thinks_stall, loaded, focus_interp);
 	logger.info('focus possible:', focus_possible.map(({ suitIndex, rank, save, illegal }) => logCard({suitIndex, rank}) + (save ? ' (save)' : ''  + (illegal ? ' (illegal)' : ''))));
 
 	const matched_inferences = focus_possible.filter(p => !p.illegal && common.thoughts[focus].inferred.has(p));

--- a/src/conventions/h-group/clue-interpretation/interpret-cm.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-cm.js
@@ -1,7 +1,7 @@
 import { CLUE } from '../../../constants.js';
 import { CARD_STATUS } from '../../../basics/Card.js';
 import { isTrash, knownAs } from '../../../basics/hanabi-util.js';
-import { variantRegexes } from '../../../variants.js';
+import { cardTouched, variantRegexes } from '../../../variants.js';
 
 import logger from '../../../tools/logger.js';
 import { logCard } from '../../../tools/log.js';
@@ -31,7 +31,8 @@ import { LEVEL } from '../h-constants.js';
 export function is_trash_clue(game, giver, clue, target, focus_order, oldCommon) {
 	const { state, common } = game;
 	const focus_thoughts = common.thoughts[focus_order];
-	const possible = clue.type == CLUE.RANK ? focus_thoughts.possible.filter(i => i.rank == clue.value) : focus_thoughts.possible;
+	const possible =
+		focus_thoughts.possible.filter(i => (clue.type !== CLUE.RANK || i.rank == clue.value) && cardTouched(i, state.variant, clue));
 	const playable_ids = possible.filter(i => !isTrash(state, oldCommon, i, focus_order, { infer: true }));
 	if (playable_ids.length === 0)
 		return true;

--- a/src/conventions/h-group/clue-interpretation/interpret-cm.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-cm.js
@@ -18,6 +18,30 @@ import { logCard } from '../../../tools/log.js';
  */
 
 /**
+ * Checks whether a clue focus is trash.
+ * @param {Game} game
+ * @param {BaseClue} clue
+ * @param {number} focus_order
+ * @param {Player} common
+ * @returns Whether the clued card is considered trash.
+ */
+export function is_trash_clue(game, clue, focus_order, common) {
+	const { state } = game;
+	const focus_thoughts = common.thoughts[focus_order];
+	if (clue.type === CLUE.RANK) {
+		const promised_ids = Utils.range(0, state.variant.suits.length).map(suitIndex => ({ suitIndex, rank: clue.value }));
+
+		if (focus_thoughts.possible.intersect(promised_ids).some(i => !isTrash(state, common, i, focus_order, { infer: true })))
+			return false;
+	}
+	else if (focus_thoughts.possible.some(c => !isTrash(state, common, c, focus_order, { infer: true })) ||
+		focus_thoughts.inferred.every(i => state.isPlayable(i) && !isTrash(state, common, i, focus_order, { infer: true }))) {
+		return false;
+	}
+	return true;
+}
+
+/**
  * Checks whether a Trash Chop Move was performed on the target. The clue must have already been registered.
  * @param {Game} game
  * @param {ClueAction} action
@@ -30,16 +54,12 @@ export function interpret_tcm(game, action, focus_order, oldCommon, assume = fal
 	const { common, state } = game;
 	const { clue, target } = action;
 	const focused_card = state.deck[focus_order];
-	const focus_thoughts = common.thoughts[focus_order];
 
 	if (!focused_card.newly_clued)
 		return [];
 
-	if (!assume) {
-		const possible = clue.type == CLUE.RANK ? focus_thoughts.possible.filter(i => i.rank == clue.value) : focus_thoughts.possible;
-		if (possible.some(i => !isTrash(state, common, i, focus_order, { infer: true })))
-			return [];
-	}
+	if (!assume && !is_trash_clue(game, clue, focus_order, oldCommon))
+		return [];
 
 	const oldest_trash_index = state.hands[target].findLastIndex(o => state.deck[o].newly_clued);
 

--- a/src/conventions/h-group/clue-interpretation/interpret-cm.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-cm.js
@@ -40,8 +40,8 @@ export function is_trash_clue(game, giver, clue, target, focus_order, oldCommon)
 		return false;
 	// There's exactly one playable card. Check if the target might be able to see it.
 	const id = playable_ids[0];
-	const could_be_in_our_hand = giver !== state.ourPlayerIndex && target !== state.ourPlayerIndex && state.hands[state.ourPlayerIndex].some(o => game.players[state.ourPlayerIndex].thoughts[o].possible.some(pid => pid.matches(id)));
-	return !game.players[target].thoughts[focus_order].possible.some(pid => pid.matches(id)) || could_be_in_our_hand;
+	const could_be_in_our_hand = giver !== state.ourPlayerIndex && target !== state.ourPlayerIndex && state.ourHand.some(o => game.me.thoughts[o].possible.has(id));
+	return !game.players[target].thoughts[focus_order].possible.has(id) || could_be_in_our_hand;
 }
 
 /**

--- a/src/conventions/h-group/clue-interpretation/interpret-cm.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-cm.js
@@ -36,16 +36,9 @@ export function interpret_tcm(game, action, focus_order, oldCommon, assume = fal
 		return [];
 
 	if (!assume) {
-		if (clue.type === CLUE.RANK) {
-			const promised_ids = Utils.range(0, state.variant.suits.length).map(suitIndex => ({ suitIndex, rank: clue.value }));
-
-			if (focus_thoughts.possible.intersect(promised_ids).some(i => !isTrash(state, oldCommon, i, focus_order, { infer: true })))
-				return [];
-		}
-		else if (focus_thoughts.possible.some(c => !isTrash(state, oldCommon, c, focus_order, { infer: true })) ||
-			focus_thoughts.inferred.every(i => state.isPlayable(i) && !isTrash(state, oldCommon, i, focus_order, { infer: true }))) {
+		const possible = clue.type == CLUE.RANK ? focus_thoughts.possible.filter(i => i.rank == clue.value) : focus_thoughts.possible;
+		if (possible.some(i => !isTrash(state, common, i, focus_order, { infer: true })))
 			return [];
-		}
 	}
 
 	const oldest_trash_index = state.hands[target].findLastIndex(o => state.deck[o].newly_clued);

--- a/src/conventions/h-group/clue-interpretation/interpret-cm.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-cm.js
@@ -23,9 +23,10 @@ import { logCard } from '../../../tools/log.js';
  * @param {ClueAction} action
  * @param {number} focus_order
  * @param {Player} oldCommon
+ * @param {boolean} assume - If true, will assume any card that could be trash is trash. Used for trash finesses.
  * @returns The orders of any chop moved cards.
  */
-export function interpret_tcm(game, action, focus_order, oldCommon) {
+export function interpret_tcm(game, action, focus_order, oldCommon, assume = false) {
 	const { common, state } = game;
 	const { clue, target } = action;
 	const focused_card = state.deck[focus_order];
@@ -34,15 +35,17 @@ export function interpret_tcm(game, action, focus_order, oldCommon) {
 	if (!focused_card.newly_clued)
 		return [];
 
-	if (clue.type === CLUE.RANK) {
-		const promised_ids = Utils.range(0, state.variant.suits.length).map(suitIndex => ({ suitIndex, rank: clue.value }));
+	if (!assume) {
+		if (clue.type === CLUE.RANK) {
+			const promised_ids = Utils.range(0, state.variant.suits.length).map(suitIndex => ({ suitIndex, rank: clue.value }));
 
-		if (focus_thoughts.possible.intersect(promised_ids).some(i => !isTrash(state, oldCommon, i, focus_order, { infer: true })))
+			if (focus_thoughts.possible.intersect(promised_ids).some(i => !isTrash(state, oldCommon, i, focus_order, { infer: true })))
+				return [];
+		}
+		else if (focus_thoughts.possible.some(c => !isTrash(state, oldCommon, c, focus_order, { infer: true })) ||
+			focus_thoughts.inferred.every(i => state.isPlayable(i) && !isTrash(state, oldCommon, i, focus_order, { infer: true }))) {
 			return [];
-	}
-	else if (focus_thoughts.possible.some(c => !isTrash(state, oldCommon, c, focus_order, { infer: true })) ||
-		focus_thoughts.inferred.every(i => state.isPlayable(i) && !isTrash(state, oldCommon, i, focus_order, { infer: true }))) {
-		return [];
+		}
 	}
 
 	const oldest_trash_index = state.hands[target].findLastIndex(o => state.deck[o].newly_clued);

--- a/src/conventions/h-group/clue-interpretation/interpret-cm.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-cm.js
@@ -28,17 +28,8 @@ import { logCard } from '../../../tools/log.js';
 export function is_trash_clue(game, clue, focus_order, oldCommon) {
 	const { state, common } = game;
 	const focus_thoughts = common.thoughts[focus_order];
-	if (clue.type === CLUE.RANK) {
-		const promised_ids = Utils.range(0, state.variant.suits.length).map(suitIndex => ({ suitIndex, rank: clue.value }));
-
-		if (focus_thoughts.possible.intersect(promised_ids).some(i => !isTrash(state, oldCommon, i, focus_order, { infer: true })))
-			return false;
-	}
-	else if (focus_thoughts.possible.some(c => !isTrash(state, oldCommon, c, focus_order, { infer: true })) ||
-		focus_thoughts.inferred.every(i => state.isPlayable(i) && !isTrash(state, oldCommon, i, focus_order, { infer: true }))) {
-		return false;
-	}
-	return true;
+	const possible = clue.type == CLUE.RANK ? focus_thoughts.possible.filter(i => i.rank == clue.value) : focus_thoughts.possible;
+	return !possible.some(i => !isTrash(state, oldCommon, i, focus_order, { infer: true }));
 }
 
 /**

--- a/src/conventions/h-group/clue-interpretation/interpret-cm.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-cm.js
@@ -22,20 +22,20 @@ import { logCard } from '../../../tools/log.js';
  * @param {Game} game
  * @param {BaseClue} clue
  * @param {number} focus_order
- * @param {Player} common
+ * @param {Player} oldCommon
  * @returns Whether the clued card is considered trash.
  */
-export function is_trash_clue(game, clue, focus_order, common) {
-	const { state } = game;
+export function is_trash_clue(game, clue, focus_order, oldCommon) {
+	const { state, common } = game;
 	const focus_thoughts = common.thoughts[focus_order];
 	if (clue.type === CLUE.RANK) {
 		const promised_ids = Utils.range(0, state.variant.suits.length).map(suitIndex => ({ suitIndex, rank: clue.value }));
 
-		if (focus_thoughts.possible.intersect(promised_ids).some(i => !isTrash(state, common, i, focus_order, { infer: true })))
+		if (focus_thoughts.possible.intersect(promised_ids).some(i => !isTrash(state, oldCommon, i, focus_order, { infer: true })))
 			return false;
 	}
-	else if (focus_thoughts.possible.some(c => !isTrash(state, common, c, focus_order, { infer: true })) ||
-		focus_thoughts.inferred.every(i => state.isPlayable(i) && !isTrash(state, common, i, focus_order, { infer: true }))) {
+	else if (focus_thoughts.possible.some(c => !isTrash(state, oldCommon, c, focus_order, { infer: true })) ||
+		focus_thoughts.inferred.every(i => state.isPlayable(i) && !isTrash(state, oldCommon, i, focus_order, { infer: true }))) {
 		return false;
 	}
 	return true;

--- a/src/conventions/h-group/clue-interpretation/interpret-cm.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-cm.js
@@ -20,12 +20,14 @@ import { LEVEL } from '../h-constants.js';
 /**
  * Checks whether a clue focus is trash.
  * @param {Game} game
+ * @param {number} giver
  * @param {BaseClue} clue
+ * @param {number} target
  * @param {number} focus_order
  * @param {Player} oldCommon
  * @returns Whether the clued card is considered trash.
  */
-export function is_trash_clue(game, clue, focus_order, oldCommon) {
+export function is_trash_clue(game, giver, clue, target, focus_order, oldCommon) {
 	const { state, common } = game;
 	const focus_thoughts = common.thoughts[focus_order];
 	const possible = clue.type == CLUE.RANK ? focus_thoughts.possible.filter(i => i.rank == clue.value) : focus_thoughts.possible;
@@ -36,11 +38,10 @@ export function is_trash_clue(game, clue, focus_order, oldCommon) {
 	const playable_cards = playable_ids.map(id => state.cardCount(id) - state.discard_stacks[id.suitIndex][id.rank - 1]).reduce((a, b) => a + b, 0);
 	if (game.level < LEVEL.TRASH_MOVES || playable_cards > 1)
 		return false;
-	// There's exactly one playable card. If we aren't the target assume we have it if it is trash.
-	if (oldCommon.playerIndex !== state.ourPlayerIndex)
-		return state.isBasicTrash(state.deck[focus_order].identity());
-	// If we are the target, check if we think it could be playable.
-	return playable_ids.some(id => oldCommon.thoughts[focus_order].possible.has(id));
+	// There's exactly one playable card. Check if the target might be able to see it.
+	const id = playable_ids[0];
+	const could_be_in_our_hand = giver !== state.ourPlayerIndex && target !== state.ourPlayerIndex && state.hands[state.ourPlayerIndex].some(o => game.players[state.ourPlayerIndex].thoughts[o].possible.some(pid => pid.matches(id)));
+	return !game.players[target].thoughts[focus_order].possible.some(pid => pid.matches(id)) || could_be_in_our_hand;
 }
 
 /**
@@ -54,13 +55,13 @@ export function is_trash_clue(game, clue, focus_order, oldCommon) {
  */
 export function interpret_tcm(game, action, focus_order, oldCommon, assume = false) {
 	const { common, state } = game;
-	const { target, clue } = action;
+	const { giver, target, clue } = action;
 	const focused_card = state.deck[focus_order];
 
 	if (!focused_card.newly_clued)
 		return [];
 
-	if (!assume && !is_trash_clue(game, clue, focus_order, oldCommon))
+	if (!assume && !is_trash_clue(game, giver, clue, target, focus_order, oldCommon))
 		return [];
 
 	const oldest_trash_index = state.hands[target].findLastIndex(o => state.deck[o].newly_clued);

--- a/src/conventions/h-group/clue-interpretation/interpret-cm.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-cm.js
@@ -5,6 +5,7 @@ import { variantRegexes } from '../../../variants.js';
 
 import logger from '../../../tools/logger.js';
 import { logCard } from '../../../tools/log.js';
+import { LEVEL } from '../h-constants.js';
 
 /**
  * @typedef {import('../../h-group.js').default} Game
@@ -28,7 +29,18 @@ export function is_trash_clue(game, clue, focus_order, oldCommon) {
 	const { state, common } = game;
 	const focus_thoughts = common.thoughts[focus_order];
 	const possible = clue.type == CLUE.RANK ? focus_thoughts.possible.filter(i => i.rank == clue.value) : focus_thoughts.possible;
-	return !possible.some(i => !isTrash(state, oldCommon, i, focus_order, { infer: true }));
+	const playable_ids = possible.filter(i => !isTrash(state, oldCommon, i, focus_order, { infer: true }));
+	if (playable_ids.length === 0)
+		return true;
+	// Check how many playable cards the focus could be.
+	const playable_cards = playable_ids.map(id => state.cardCount(id) - state.discard_stacks[id.suitIndex][id.rank - 1]).reduce((a, b) => a + b, 0);
+	if (game.level < LEVEL.TRASH_MOVES || playable_cards > 1)
+		return false;
+	// There's exactly one playable card. If we aren't the target assume we have it if it is trash.
+	if (oldCommon.playerIndex !== state.ourPlayerIndex)
+		return state.isBasicTrash(state.deck[focus_order].identity());
+	// If we are the target, check if we think it could be playable.
+	return playable_ids.some(id => oldCommon.thoughts[focus_order].possible.has(id));
 }
 
 /**
@@ -42,7 +54,7 @@ export function is_trash_clue(game, clue, focus_order, oldCommon) {
  */
 export function interpret_tcm(game, action, focus_order, oldCommon, assume = false) {
 	const { common, state } = game;
-	const { clue, target } = action;
+	const { target, clue } = action;
 	const focused_card = state.deck[focus_order];
 
 	if (!focused_card.newly_clued)

--- a/src/conventions/h-group/clue-interpretation/interpret-cm.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-cm.js
@@ -14,6 +14,7 @@ import { LEVEL } from '../h-constants.js';
  * @typedef {import('../../../basics/Card.js').ActualCard} ActualCard
  * @typedef {import('../../../basics/Card.js').Card} Card
  * @typedef {import('../../../types.js').BaseClue} BaseClue
+ * @typedef {import('../../../types.js').Connection} Connection
  * @typedef {import('../../../basics/Action.ts').ClueAction} ClueAction
  */
 

--- a/src/conventions/h-group/clue-interpretation/interpret-cm.js
+++ b/src/conventions/h-group/clue-interpretation/interpret-cm.js
@@ -2,7 +2,6 @@ import { CLUE } from '../../../constants.js';
 import { CARD_STATUS } from '../../../basics/Card.js';
 import { isTrash, knownAs } from '../../../basics/hanabi-util.js';
 import { variantRegexes } from '../../../variants.js';
-import * as Utils from '../../../tools/util.js';
 
 import logger from '../../../tools/logger.js';
 import { logCard } from '../../../tools/log.js';

--- a/src/conventions/h-group/clue-interpretation/own-finesses.js
+++ b/src/conventions/h-group/clue-interpretation/own-finesses.js
@@ -368,7 +368,6 @@ export function find_own_trash_finesses(game, action, focus, identity) {
 	const connections = /** @type {Connection[]} */ ([]);
 	const already_connected = [focus];
 
-	let finesses = 0;
 	const direct = common.thoughts[focus].possible.some(id => state.isPlayable(id));
 
 	for (let next_rank = hypo_state.play_stacks[suitIndex] + 1; next_rank <= rank; next_rank++) {
@@ -376,7 +375,8 @@ export function find_own_trash_finesses(game, action, focus, identity) {
 		const ignoreOrders = getIgnoreOrders(game, next_rank - state.play_stacks[suitIndex] - 1, suitIndex);
 
 		const options = { assumeTruth: true, bluffed: false };
-		const curr_connections = connect(hypo_game, action, next_identity, direct, already_connected, ignoreOrders, target, [], finesses, options);
+		// # of finesses is only used at level 1, since we are necessarily at level 14+ to be finding trash finesses we pass 0.
+		const curr_connections = connect(hypo_game, action, next_identity, direct, already_connected, ignoreOrders, target, [], /*finesses=*/ 0, options);
 
 		if (curr_connections.length === 0)
 			break;
@@ -385,10 +385,7 @@ export function find_own_trash_finesses(game, action, focus, identity) {
 		for (const connection of curr_connections) {
 			connections.push(connection);
 
-			const { order, hidden, type } = connection;
-
-			if (type === 'finesse')
-				finesses++;
+			const { order, hidden } = connection;
 
 			if (hidden) {
 				const id = state.deck[order].identity();

--- a/src/conventions/h-group/clue-interpretation/own-finesses.js
+++ b/src/conventions/h-group/clue-interpretation/own-finesses.js
@@ -65,7 +65,7 @@ function own_prompt(game, finesses, prompt, identity) {
  * @param {number} ignorePlayer
  * @param {number[]} selfRanks
  * @param {number} finesses
- * @param {{ assumeTruth?: boolean, bluffed?: boolean }} [options]
+ * @param {{ assumeTruth?: boolean, bluffed?: boolean, immediate?: boolean }} [options]
  * @returns {Connection[]}
  */
 function connect(game, action, identity, looksDirect, connected, ignoreOrders, ignorePlayer, selfRanks, finesses, options = {}) {
@@ -369,12 +369,14 @@ export function find_own_trash_finesses(game, action, focus, identity) {
 	const already_connected = [focus];
 
 	const direct = common.thoughts[focus].possible.some(id => state.isPlayable(id));
+	// We require an immediate play if the target can't know they the matching play.
+	const immediate = common.thoughts[focus].inferred.length > 1;
 
 	for (let next_rank = hypo_state.play_stacks[suitIndex] + 1; next_rank <= rank; next_rank++) {
 		const next_identity = { suitIndex, rank: next_rank };
 		const ignoreOrders = getIgnoreOrders(game, next_rank - state.play_stacks[suitIndex] - 1, suitIndex);
 
-		const options = { assumeTruth: true, bluffed: false };
+		const options = { assumeTruth: true, bluffed: false, immediate };
 		// # of finesses is only used at level 1, since we are necessarily at level 14+ to be finding trash finesses we pass 0.
 		const curr_connections = connect(hypo_game, action, next_identity, direct, already_connected, ignoreOrders, target, [], /*finesses=*/ 0, options);
 

--- a/src/conventions/h-group/clue-interpretation/own-finesses.js
+++ b/src/conventions/h-group/clue-interpretation/own-finesses.js
@@ -374,7 +374,7 @@ export function find_own_trash_finesses(game, action, focus, identity) {
 
 	for (let next_rank = hypo_state.play_stacks[suitIndex] + 1; next_rank <= rank; next_rank++) {
 		const next_identity = { suitIndex, rank: next_rank };
-		const ignoreOrders = getIgnoreOrders(game, next_rank - state.play_stacks[suitIndex] - 1, suitIndex);
+		const ignoreOrders = getIgnoreOrders(game, next_rank - state.play_stacks[suitIndex] - 1, suitIndex, true);
 
 		const options = { assumeTruth: true, bluffed: false, immediate };
 		// # of finesses is only used at level 1, since we are necessarily at level 14+ to be finding trash finesses we pass 0.

--- a/src/conventions/h-group/clue-interpretation/own-finesses.js
+++ b/src/conventions/h-group/clue-interpretation/own-finesses.js
@@ -344,6 +344,84 @@ export function find_own_finesses(game, action, focus, identity, looksDirect, ig
 }
 
 /**
+ * Looks for a trash finesse / bluff through own hand.
+ * @param {Game} game
+ * @param {ClueAction} action
+ * @param {number} focus
+ * @param {Identity} identity
+ * @throws {IllegalInterpretation} If no connection can be found.
+ * @returns {Connection[] | undefined}
+ */
+export function find_own_trash_finesses(game, action, focus, identity) {
+	const { common, state } = game;
+	const { target } = action;
+	const { suitIndex, rank } = identity;
+
+	// Create hypothetical state where we have the missing cards (and others can elim from them)
+	const hypo_game = game.shallowCopy();
+	hypo_game.state = state.shallowCopy();
+	hypo_game.state.play_stacks = state.play_stacks.slice();
+	hypo_game.common = common.clone();
+
+	const { state: hypo_state, common: hypo_common } = hypo_game;
+
+	const connections = /** @type {Connection[]} */ ([]);
+	const already_connected = [focus];
+
+	let finesses = 0;
+	const direct = common.thoughts[focus].possible.some(id => state.isPlayable(id));
+
+	for (let next_rank = hypo_state.play_stacks[suitIndex] + 1; next_rank <= rank; next_rank++) {
+		const next_identity = { suitIndex, rank: next_rank };
+		const ignoreOrders = getIgnoreOrders(game, next_rank - state.play_stacks[suitIndex] - 1, suitIndex);
+
+		const options = { assumeTruth: true, bluffed: false };
+		const curr_connections = connect(hypo_game, action, next_identity, direct, already_connected, ignoreOrders, target, [], finesses, options);
+
+		if (curr_connections.length === 0)
+			break;
+
+		let allHidden = true;
+		for (const connection of curr_connections) {
+			connections.push(connection);
+
+			const { order, hidden, type } = connection;
+
+			if (type === 'finesse')
+				finesses++;
+
+			if (hidden) {
+				const id = state.deck[order].identity();
+
+				if (id !== undefined) {
+					hypo_state.play_stacks[id.suitIndex]++;
+					hypo_common.hypo_stacks[id.suitIndex]++;		// Everyone knows this card is playing
+				}
+			}
+			else {
+				allHidden = false;
+
+				// Assume this is actually the card
+				hypo_common.updateThoughts(order, (draft) => { draft.inferred = hypo_common.thoughts[order].inferred.intersect(next_identity); });
+				Object.assign(hypo_common, hypo_common.good_touch_elim(hypo_state));
+			}
+			already_connected.push(order);
+		}
+
+		// Hidden connection, need to look for this rank again
+		if (allHidden)
+			next_rank--;
+		else
+			hypo_state.play_stacks[suitIndex]++;
+	}
+
+	if (hypo_state.play_stacks[suitIndex] !== rank)
+		return undefined;
+
+	return connections;
+}
+
+/**
  * @param {Game} game
  * @param {Identity} identity
  * @param {number[]} [connected] 		The orders of cards that have previously connected.

--- a/src/conventions/h-group/h-constants.js
+++ b/src/conventions/h-group/h-constants.js
@@ -27,6 +27,7 @@ export const CLUE_INTERP = /** @type {const} */ ({
 	MISTAKE: 'mistake',
 	PLAY: 'play',
 	SAVE: 'save',
+	TRASH_FINESSE: 'trash finesse',
 	STALL_5: '5 stall',
 	STALL_TEMPO: 'tempo stall',
 	STALL_LOCKED: 'locked save',

--- a/src/conventions/h-group/h-constants.js
+++ b/src/conventions/h-group/h-constants.js
@@ -11,6 +11,7 @@ export const LEVEL = /** @type {const} */ ({
 	BLUFFS: 11,
 	CONTEXT: 12,
 	INTERMEDIATE_BLUFFS: 13,
+	TRASH_MOVES: 14,
 });
 
 export const ACTION_PRIORITY = /** @type {const} */ ({
@@ -55,6 +56,11 @@ export const DISCARD_INTERP = /** @type {const} */ ({
 	POS_MISPLAY: 'pos misplay',
 	GENTLEMANS: 'gd',
 	BATON: 'baton'
+});
+
+export const FOCUS_INTERP = /** @type {const} */ ({
+	NORMAL: 'normal',
+	TRASH_PUSH: 'trash push',
 });
 
 export const STALL_INDICES = /** @type {const} */ ({

--- a/src/conventions/h-group/hanabi-logic.js
+++ b/src/conventions/h-group/hanabi-logic.js
@@ -1,11 +1,13 @@
 import { CLUE } from '../../constants.js';
 import { CARD_STATUS } from '../../basics/Card.js';
 import { colourableSuits, variantRegexes } from '../../variants.js';
-import { knownAs, visibleFind } from '../../basics/hanabi-util.js';
+import { isTrash, knownAs, visibleFind } from '../../basics/hanabi-util.js';
 import { order_1s } from './action-helper.js';
 import * as Utils from '../../tools/util.js';
 
-import { logClue } from '../../tools/log.js';
+import { logCard, logClue } from '../../tools/log.js';
+import { FOCUS_INTERP, LEVEL } from './h-constants.js';
+import logger from '../../tools/logger.js';
 
 /**
  * @typedef {import('../h-group.js').default} Game
@@ -20,6 +22,53 @@ import { logClue } from '../../tools/log.js';
  * @typedef {import('../../types.js').Identity} Identity
  * @typedef {import('../../types.js').FocusResult} FocusResult
  */
+
+/**
+ * Checks whether a Trash Push was performed on the target. The list must include the chop position.
+ * @param {Game} game
+ * @param {number[]} hand
+ * @param {Player} player
+ * @param {number[]} list 	The orders of all cards that were just clued.
+ * @param {BaseClue} clue
+ * @returns The order of the trash pushed card or -1 if no card is trash pushed.
+ */
+export function interpret_tp(game, hand, player, list, clue) {
+	const { common, state } = game;
+	const chopIndex = player.chopIndex(hand);
+	if (chopIndex === -1)
+		return -1;
+	const chop = hand[chopIndex];
+	if (!list.includes(chop))
+		return -1;
+
+	// If this is a trash push, find the focused card which is the new chop after the clue.
+	let tp_focus = -1;
+	for (let i = chopIndex - 1; i >= 0; i--) {
+		if (player.thoughts[hand[i]].status !== undefined)
+			continue;
+		if (list.includes(hand[i]))
+			continue;
+		tp_focus = hand[i];
+		break;
+	}
+	if (tp_focus === -1)
+		return -1;
+
+	// Check if the clued chop card could be useful. If so, this cannot be a trash push.
+	const chop_thoughts = player.thoughts[chop];
+	if (clue.type === CLUE.RANK) {
+		const promised_ids = Utils.range(0, state.variant.suits.length).map(suitIndex => ({ suitIndex, rank: clue.value }));
+
+		if (chop_thoughts.possible.intersect(promised_ids).some(i => !isTrash(state, common, i, chop, { infer: true })))
+			return -1;
+	}
+	else if (chop_thoughts.possible.some(c => !isTrash(state, common, c, chop, { infer: true })) ||
+		chop_thoughts.inferred.every(i => state.isPlayable(i) && !isTrash(state, common, i, chop, { infer: true }))) {
+		return undefined;
+	}
+
+	return tp_focus;
+}
 
 /**
  * Finds the focused card and whether it was on chop before the clue.
@@ -37,8 +86,19 @@ export function determine_focus(game, hand, player, list, clue) {
 	const chop = player.chop(hand);
 
 	// Chop card exists, check for chop focus
-	if (chop !== undefined && list.includes(chop))
-		return { focus: chop, chop: true, positional: false };
+	if (chop !== undefined && list.includes(chop)) {
+		// Check for trash push which focuses new chop.
+		if (game.level >= LEVEL.TRASH_MOVES) {
+			const tp = interpret_tp(game, hand, player, list, clue);
+
+			if (tp != -1) {
+				logger.highlight('cyan', `trash push on ${logCard(state.deck[tp])} ${tp}`);
+				return { focus: tp, chop: true, positional: false, focus_interp: FOCUS_INTERP.TRASH_PUSH };
+			}
+		}
+
+		return { focus: chop, chop: true, positional: false, focus_interp: FOCUS_INTERP.NORMAL };
+	}
 
 	const pink_choice_tempo = clue.type === CLUE.RANK && state.includesVariant(variantRegexes.pinkish) &&
 		list.every(o => state.deck[o].clued) &&
@@ -49,20 +109,20 @@ export function determine_focus(game, hand, player, list, clue) {
 			(cl.type === CLUE.RANK && cl.value !== clue.value)));
 
 	if (pink_choice_tempo)
-		return { focus: hand[clue.value - 1], chop: false, positional: true };
+		return { focus: hand[clue.value - 1], chop: false, positional: true, focus_interp: FOCUS_INTERP.NORMAL };
 
 	const brown_tempo = clue.type === CLUE.COLOUR && /Brown/.test(colourableSuits(state.variant)[clue.value]) &&
 		list.every(o => state.deck[o].clued);
 
 	if (brown_tempo)
-		return { focus: hand.findLast(o => list.includes(o)), chop: false, positional: true };
+		return { focus: hand.findLast(o => list.includes(o)), chop: false, positional: true, focus_interp: FOCUS_INTERP.NORMAL };
 
 	if (clue.type === CLUE.RANK && clue.value === 1) {
 		const unknown_1s = list.filter(o => unknown_1(state.deck[o], true));
 		const ordered_1s = order_1s(state, common, unknown_1s, { no_filter: true });
 
 		if (ordered_1s.length > 0)
-			return { focus: ordered_1s[0], chop: false, positional: false };
+			return { focus: ordered_1s[0], chop: false, positional: false, focus_interp: FOCUS_INTERP.NORMAL };
 	}
 
 	const sorted_list = list.toSorted((a, b) => b - a);
@@ -78,7 +138,7 @@ export function determine_focus(game, hand, player, list, clue) {
 		if (card_amt > 0) {
 			const colors_available_amt = colourableSuits(state.variant).length;
 			const focus_index = (clue.value - colors_available_amt + colors_available_amt*card_amt) % card_amt;
-			return { focus: possible_muddy_cards[focus_index], chop: false, positional: true };
+			return { focus: possible_muddy_cards[focus_index], chop: false, positional: true, focus_interp: FOCUS_INTERP.NORMAL };
 		}
 		// if there are 0 possible muddy cards, all the muddy code does nothing and it just finds the normal tempo clue focus.
 	}
@@ -103,7 +163,7 @@ export function determine_focus(game, hand, player, list, clue) {
 		throw new Error('No focus found!');
 	}
 
-	return { focus, chop: false, positional: false };
+	return { focus, chop: false, positional: false, focus_interp: FOCUS_INTERP.NORMAL };
 }
 
 /**

--- a/src/conventions/h-group/hanabi-logic.js
+++ b/src/conventions/h-group/hanabi-logic.js
@@ -30,10 +30,12 @@ import { is_trash_clue } from './clue-interpretation/interpret-cm.js';
  * @param {number[]} hand
  * @param {Player} player
  * @param {number[]} list 	The orders of all cards that were just clued.
+ * @param {number} giver
+ * @param {number} target
  * @param {BaseClue} clue
  * @returns The order of the trash pushed card or -1 if no card is trash pushed.
  */
-export function interpret_tp(game, hand, player, list, clue) {
+export function interpret_tp(game, hand, player, list, giver, target, clue) {
 	const chopIndex = player.chopIndex(hand);
 	if (chopIndex === -1)
 		return -1;
@@ -55,7 +57,7 @@ export function interpret_tp(game, hand, player, list, clue) {
 		return -1;
 
 	// Check if the clued card is a trash clue.
-	if (!is_trash_clue(game, clue, chop, player))
+	if (!is_trash_clue(game, giver, clue, target, chop, player))
 		return -1;
 
 	return tp_focus;
@@ -69,10 +71,12 @@ export function interpret_tp(game, hand, player, list, clue) {
  * @param {number[]} hand
  * @param {Player} player
  * @param {number[]} list 	The orders of all cards that were just clued.
+ * @param {number} giver
+ * @param {number} target
  * @param {BaseClue} clue
  * @returns {FocusResult}
  */
-export function determine_focus(game, hand, player, list, clue) {
+export function determine_focus(game, hand, player, list, giver, target, clue) {
 	const { common, state } = game;
 	const chop = player.chop(hand);
 
@@ -80,7 +84,7 @@ export function determine_focus(game, hand, player, list, clue) {
 	if (chop !== undefined && list.includes(chop)) {
 		// Check for trash push which focuses new chop.
 		if (game.level >= LEVEL.TRASH_MOVES) {
-			const tp = interpret_tp(game, hand, player, list, clue);
+			const tp = interpret_tp(game, hand, player, list, giver, target, clue);
 
 			if (tp != -1) {
 				logger.highlight('cyan', `trash push on ${logCard(state.deck[tp])} ${tp}`);

--- a/src/conventions/h-group/hanabi-logic.js
+++ b/src/conventions/h-group/hanabi-logic.js
@@ -64,7 +64,7 @@ export function interpret_tp(game, hand, player, list, clue) {
 	}
 	else if (chop_thoughts.possible.some(c => !isTrash(state, common, c, chop, { infer: true })) ||
 		chop_thoughts.inferred.every(i => state.isPlayable(i) && !isTrash(state, common, i, chop, { infer: true }))) {
-		return undefined;
+		return -1;
 	}
 
 	return tp_focus;

--- a/src/conventions/h-group/hanabi-logic.js
+++ b/src/conventions/h-group/hanabi-logic.js
@@ -1,13 +1,14 @@
 import { CLUE } from '../../constants.js';
 import { CARD_STATUS } from '../../basics/Card.js';
 import { colourableSuits, variantRegexes } from '../../variants.js';
-import { isTrash, knownAs, visibleFind } from '../../basics/hanabi-util.js';
+import { knownAs, visibleFind } from '../../basics/hanabi-util.js';
 import { order_1s } from './action-helper.js';
 import * as Utils from '../../tools/util.js';
 
 import { logCard, logClue } from '../../tools/log.js';
 import { FOCUS_INTERP, LEVEL } from './h-constants.js';
 import logger from '../../tools/logger.js';
+import { is_trash_clue } from './clue-interpretation/interpret-cm.js';
 
 /**
  * @typedef {import('../h-group.js').default} Game
@@ -33,7 +34,6 @@ import logger from '../../tools/logger.js';
  * @returns The order of the trash pushed card or -1 if no card is trash pushed.
  */
 export function interpret_tp(game, hand, player, list, clue) {
-	const { common, state } = game;
 	const chopIndex = player.chopIndex(hand);
 	if (chopIndex === -1)
 		return -1;
@@ -54,10 +54,8 @@ export function interpret_tp(game, hand, player, list, clue) {
 	if (tp_focus === -1)
 		return -1;
 
-	// Check if the clued chop card could be useful. If so, this cannot be a trash push.
-	const chop_thoughts = player.thoughts[chop];
-	const possible = clue.type == CLUE.RANK ? chop_thoughts.possible.filter(i => i.rank == clue.value) : chop_thoughts.possible;
-	if (possible.some(i => !isTrash(state, common, i, chop, { infer: true })))
+	// Check if the clued card is a trash clue.
+	if (!is_trash_clue(game, clue, chop, player))
 		return -1;
 
 	return tp_focus;

--- a/src/conventions/h-group/hanabi-logic.js
+++ b/src/conventions/h-group/hanabi-logic.js
@@ -56,16 +56,9 @@ export function interpret_tp(game, hand, player, list, clue) {
 
 	// Check if the clued chop card could be useful. If so, this cannot be a trash push.
 	const chop_thoughts = player.thoughts[chop];
-	if (clue.type === CLUE.RANK) {
-		const promised_ids = Utils.range(0, state.variant.suits.length).map(suitIndex => ({ suitIndex, rank: clue.value }));
-
-		if (chop_thoughts.possible.intersect(promised_ids).some(i => !isTrash(state, common, i, chop, { infer: true })))
-			return -1;
-	}
-	else if (chop_thoughts.possible.some(c => !isTrash(state, common, c, chop, { infer: true })) ||
-		chop_thoughts.inferred.every(i => state.isPlayable(i) && !isTrash(state, common, i, chop, { infer: true }))) {
+	const possible = clue.type == CLUE.RANK ? chop_thoughts.possible.filter(i => i.rank == clue.value) : chop_thoughts.possible;
+	if (possible.some(i => !isTrash(state, common, i, chop, { infer: true })))
 		return -1;
-	}
 
 	return tp_focus;
 }

--- a/src/conventions/h-group/interpret-discard.js
+++ b/src/conventions/h-group/interpret-discard.js
@@ -171,7 +171,7 @@ export function check_tocm(game, action) {
 	const { order, playerIndex } = action;
 
 	const ordered_trash = order_trash(game, playerIndex);
-	let offset = ordered_trash.findIndex(o => o === order);
+	let offset = ordered_trash.indexOf(order);
 
 	if (offset === -1)
 		return [];

--- a/src/conventions/h-group/interpret-discard.js
+++ b/src/conventions/h-group/interpret-discard.js
@@ -230,16 +230,6 @@ export function interpret_discard(game, action) {
 		}
 	}
 
-	if (game.level >= LEVEL.TRASH_MOVES && !failed) {
-		const ocm_orders = check_tocm(game, action);
-
-		if (ocm_orders.length > 0) {
-			game.interpretMove(DISCARD_INTERP.TOCM_ORDER);
-			for (const ocm_order of ocm_orders)
-				common.updateThoughts(ocm_order, (draft) => { draft.updateStatus(CARD_STATUS.CM); });
-		}
-	}
-
 	const newGame = Basics.onDiscard(game, action);
 	Basics.mutate(game, newGame);
 
@@ -351,6 +341,16 @@ export function interpret_discard(game, action) {
 			if (interp !== DISCARD_INTERP.NONE) {
 				resolve_discard(game, action, interp);
 				return game;
+			}
+		} else {
+			if (game.level >= LEVEL.TRASH_MOVES && !failed) {
+				const ocm_orders = check_tocm(game, action);
+
+				if (ocm_orders.length > 0) {
+					game.interpretMove(DISCARD_INTERP.TOCM_ORDER);
+					for (const ocm_order of ocm_orders)
+						common.updateThoughts(ocm_order, (draft) => { draft.updateStatus(CARD_STATUS.CM); });
+				}
 			}
 		}
 	}

--- a/src/conventions/h-group/interpret-discard.js
+++ b/src/conventions/h-group/interpret-discard.js
@@ -10,6 +10,7 @@ import { logCard, logConnection } from '../../tools/log.js';
 import { getRealConnects } from './hanabi-logic.js';
 import { check_ocm } from './interpret-play.js';
 import { interpret_baton, interpret_gd } from '../shared/special-discards.js';
+import { order_trash } from './action-helper.js';
 
 /**
  * @typedef {import('../h-group.js').default} Game
@@ -161,6 +162,49 @@ function resolve_discard(game, action, interp) {
 }
 
 /**
+ * @param {Game} game
+ * @param {DiscardAction} action
+ * @returns The orders of the chop moved cards.
+ */
+export function check_tocm(game, action) {
+	const { common, state } = game;
+	const { order, playerIndex } = action;
+
+	const ordered_trash = order_trash(game, playerIndex);
+	let offset = ordered_trash.findIndex(o => o === order);
+
+	if (offset === -1)
+		return [];
+
+	// If we have a known playable, the order of the TOCM is effectively one later
+	// since the expected action is a play.
+	const shout = common.thinksPlayables(state, playerIndex).length > 0;
+	if (shout)
+		offset += 1;
+
+	if (offset === 0) {
+		logger.info('discarded known trash in correct order, no tocm');
+		return [];
+	}
+
+	const target = (playerIndex + offset) % state.numPlayers;
+	if (target === playerIndex) {
+		// Just going to assume no double order chop moves in 3p
+		logger.error('double trash order chop move???');
+		return [];
+	}
+
+	const chop = common.chop(state.hands[target]);
+	if (chop === undefined) {
+		logger.warn(`attempted to interpret tocm on ${state.playerNames[target]}, but they have no chop`);
+		return [];
+	}
+
+	logger.highlight('cyan', `trash order chop move on ${state.playerNames[target]}, distance ${offset}`);
+	return [chop];
+}
+
+/**
  * Interprets (writes notes) for a discard of the given card.
  * 
  * Impure!
@@ -183,6 +227,16 @@ export function interpret_discard(game, action) {
 		if (ocm_order !== -1) {
 			common.updateThoughts(ocm_order, (draft) => { draft.updateStatus(CARD_STATUS.CM); });
 			game.interpretMove(PLAY_INTERP.CM_ORDER);
+		}
+	}
+
+	if (game.level >= LEVEL.TRASH_MOVES && !failed) {
+		const ocm_orders = check_tocm(game, action);
+
+		if (ocm_orders.length > 0) {
+			game.interpretMove(DISCARD_INTERP.TOCM_ORDER);
+			for (const ocm_order of ocm_orders)
+				common.updateThoughts(ocm_order, (draft) => { draft.updateStatus(CARD_STATUS.CM); });
 		}
 	}
 

--- a/src/conventions/h-group/interpret-discard.js
+++ b/src/conventions/h-group/interpret-discard.js
@@ -229,6 +229,8 @@ export function interpret_discard(game, action) {
 			game.interpretMove(PLAY_INTERP.CM_ORDER);
 		}
 	}
+	// Need to check for TOCM before the discard is processed.
+	const tocm_orders = game.level >= LEVEL.TRASH_MOVES ? check_tocm(game, action) : [];
 
 	const newGame = Basics.onDiscard(game, action);
 	Basics.mutate(game, newGame);
@@ -323,8 +325,12 @@ export function interpret_discard(game, action) {
 
 			if (interp === DISCARD_INTERP.SCREAM || interp === DISCARD_INTERP.SHOUT) {
 				state.discard_state = interp;
-
-				if (chop === undefined) {
+				if (interp === DISCARD_INTERP.SHOUT && tocm_orders.length > 0) {
+					logger.info(`intepreting sdocm`);
+					game.interpretMove(DISCARD_INTERP.TOCM_ORDER);
+					for (const ocm_order of tocm_orders)
+						common.updateThoughts(ocm_order, (draft) => { draft.updateStatus(CARD_STATUS.CM); });
+				} else if (chop === undefined) {
 					logger.warn(`${state.playerNames[nextPlayerIndex]} has no chop!`);
 					interp = DISCARD_INTERP.NONE;
 				}
@@ -342,16 +348,10 @@ export function interpret_discard(game, action) {
 				resolve_discard(game, action, interp);
 				return game;
 			}
-		} else {
-			if (game.level >= LEVEL.TRASH_MOVES && !failed) {
-				const ocm_orders = check_tocm(game, action);
-
-				if (ocm_orders.length > 0) {
-					game.interpretMove(DISCARD_INTERP.TOCM_ORDER);
-					for (const ocm_order of ocm_orders)
-						common.updateThoughts(ocm_order, (draft) => { draft.updateStatus(CARD_STATUS.CM); });
-				}
-			}
+		} else if (tocm_orders.length > 0) {
+			game.interpretMove(DISCARD_INTERP.TOCM_ORDER);
+			for (const ocm_order of tocm_orders)
+				common.updateThoughts(ocm_order, (draft) => { draft.updateStatus(CARD_STATUS.CM); });
 		}
 	}
 

--- a/src/conventions/h-group/update-wcs.js
+++ b/src/conventions/h-group/update-wcs.js
@@ -282,7 +282,7 @@ export function resolve_card_retained(game, waiting_connection) {
 		logger.warn(`${state.playerNames[reacting]} didn't play into ${type}, removing inference ${logCard(inference)}`);
 
 		// Don't rewind if this is a symmetric connection that doesn't involve us
-		if (reacting !== state.ourPlayerIndex && !(symmetric && connections.every((conn, i) => i < conn_index || conn.reacting !== state.ourPlayerIndex))) {
+		if (reacting !== state.ourPlayerIndex && (target === state.ourPlayerIndex || !(symmetric && connections.every((conn, i) => i < conn_index || conn.reacting !== state.ourPlayerIndex)))) {
 			const real_connects = getRealConnects(connections, conn_index);
 			const new_game = game.rewind(action_index, [{ type: 'ignore', conn_index: real_connects, order, inference }]);
 			if (new_game) {

--- a/src/conventions/h-group/urgent-actions.js
+++ b/src/conventions/h-group/urgent-actions.js
@@ -432,19 +432,25 @@ function save_urgency(game, save, nextPriority, potential_cluers, early_expected
 		}
 	}
 
+	const has_playables = common.thinksPlayables(state, state.ourPlayerIndex).length > 0;
+	const has_known_trash = common.thinksTrash(state, state.ourPlayerIndex).length > 0;
 	const scream_available = !finessed_card &&
 		!state.inEndgame() &&
 		game.level >= LEVEL.LAST_RESORTS &&
-		common.thinksPlayables(state, state.ourPlayerIndex).length > 0 &&
+		(has_playables || (game.level >= LEVEL.TRASH_MOVES && has_known_trash)) &&
 		target === state.nextPlayerIndex(state.ourPlayerIndex) &&
 		!me.thinksLoaded(state, target);
 
 	if (scream_available) {
-		const trash = me.thinksTrash(state, state.ourPlayerIndex).filter(o =>
-			state.deck[o].clued && me.thoughts[o].inferred.every(i => state.isBasicTrash(i)));
+		// If we have a playable, we can scream by discarding trash instead. At level 14
+		// this is interpreted as a shout discard order chop move instead.
+		if (has_playables && game.level < LEVEL.TRASH_MOVES) {
+			const trash = me.thinksTrash(state, state.ourPlayerIndex).filter(o =>
+				state.deck[o].clued && me.thoughts[o].inferred.every(i => state.isBasicTrash(i)));
 
-		if (trash.length > 0)
-			return { urgency: PRIORITY.PLAY_OVER_SAVE + nextPriority, action: { type: ACTION.DISCARD, target: trash[0] } };
+			if (trash.length > 0)
+				return { urgency: PRIORITY.PLAY_OVER_SAVE + nextPriority, action: { type: ACTION.DISCARD, target: trash[0] } };
+		}
 
 		// As a last resort, only scream discard if it is playable or critical.
 		const save_card = state.deck[game.players[target].chop(state.hands[target])];

--- a/src/conventions/h-group/urgent-actions.js
+++ b/src/conventions/h-group/urgent-actions.js
@@ -3,7 +3,7 @@ import { ACTION_PRIORITY as PRIORITY, LEVEL, CLUE_INTERP } from './h-constants.j
 import { get_result } from './clue-finder/determine-clue.js';
 import { playersBetween, unknown_1, valuable_tempo_clue } from './hanabi-logic.js';
 import { cardValue, save2 } from '../../basics/hanabi-util.js';
-import { find_clue_value, order_1s } from './action-helper.js';
+import { find_clue_value, order_1s, order_trash } from './action-helper.js';
 import { find_expected_clue, save_clue_value } from './clue-finder/clue-finder.js';
 import { cardTouched } from '../../variants.js';
 import { find_sarcastics } from '../shared/sarcastic.js';
@@ -405,6 +405,28 @@ function save_urgency(game, save, nextPriority, potential_cluers, early_expected
 				return {
 					urgency: PRIORITY.ONLY_SAVE + nextPriority,
 					action: { type: ACTION.PLAY, target: ordered_1s[distance] }
+				};
+			}
+		}
+	}
+
+	// Check if Trash Order Chop Move is available.
+	if (game.level >= LEVEL.TRASH_MOVES) {
+		const ordered_trash = order_trash(game, state.ourPlayerIndex);
+		const distance = (target + state.numPlayers - state.ourPlayerIndex) % state.numPlayers;
+
+		// If we want to OCM the next player (distance 1), we need at least two unknown 1s.
+		if (ordered_trash.length > distance) {
+			// Temporarily chop move the chop card
+			const chop = me.chop(hand);
+			const old_chop_value = cardValue(state, me, state.deck[chop]);
+			const new_chop_value = me.simulateCM([chop]).chopValue(state, target);
+
+			// Make sure the old chop is equal or better than the new one
+			if (old_chop_value >= new_chop_value) {
+				return {
+					urgency: PRIORITY.ONLY_SAVE + nextPriority,
+					action: { type: ACTION.DISCARD, target: ordered_trash[distance] }
 				};
 			}
 		}

--- a/src/conventions/h-group/urgent-actions.js
+++ b/src/conventions/h-group/urgent-actions.js
@@ -401,7 +401,7 @@ function save_urgency(game, save, nextPriority, potential_cluers, early_expected
 			const new_chop_value = me.simulateCM([chop]).chopValue(state, target);
 
 			// Make sure the old chop is equal or better than the new one
-			if (old_chop_value >= new_chop_value) {
+			if (old_chop_value > 0 && old_chop_value >= new_chop_value) {
 				return {
 					urgency: PRIORITY.ONLY_SAVE + nextPriority,
 					action: { type: ACTION.PLAY, target: ordered_1s[distance] }
@@ -423,7 +423,7 @@ function save_urgency(game, save, nextPriority, potential_cluers, early_expected
 			const new_chop_value = me.simulateCM([chop]).chopValue(state, target);
 
 			// Make sure the old chop is equal or better than the new one
-			if (old_chop_value >= new_chop_value) {
+			if (old_chop_value > 0 && old_chop_value >= new_chop_value) {
 				return {
 					urgency: PRIORITY.ONLY_SAVE + nextPriority,
 					action: { type: ACTION.DISCARD, target: ordered_trash[distance] }

--- a/src/tools/log.js
+++ b/src/tools/log.js
@@ -238,7 +238,7 @@ export function logConnections(connections, nextIdentity) {
 	else if (nextIdentity.rank <= 5)
 		identities = logCard(nextIdentity);
 
-	return `[${connections.map(conn => logConnection(conn)).join(' -> ')} ${identities}]`;
+	return `[${connections.map(conn => logConnection(conn)).join(' -> ')} ${identities ? `-> ${identities}?` : ''}]`;
 }
 
 /**

--- a/src/tools/log.js
+++ b/src/tools/log.js
@@ -229,12 +229,16 @@ export function logConnection(connection) {
 
 /**
  * @param {Connection[]} connections
- * @param {Identity} nextIdentity
+ * @param {Identity | Identity[]} nextIdentity
  */
 export function logConnections(connections, nextIdentity) {
-	const { rank } = nextIdentity;
+	let identities = '';
+	if (Array.isArray(nextIdentity))
+		identities = nextIdentity.map(logCard).join(',');
+	else if (nextIdentity.rank <= 5)
+		identities = logCard(nextIdentity);
 
-	return `[${connections.map(conn => logConnection(conn)).join(' -> ')} ${(rank <= 5) ? `-> ${logCard(nextIdentity)}?` : ''}]`;
+	return `[${connections.map(conn => logConnection(conn)).join(' -> ')} ${identities}]`;
 }
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -3,6 +3,7 @@
  * @typedef {typeof import('./constants.js').CLUE} CLUE
  * @typedef {typeof import('./constants.js').ACTION} ACTION
  * @typedef {typeof import('./conventions/h-group/h-constants.js').CLUE_INTERP} CLUE_INTERP
+ * @typedef {typeof import('./conventions/h-group/h-constants.js').FOCUS_INTERP} FOCUS_INTERP
  * @typedef {typeof import('./conventions/h-group/h-constants.js').PLAY_INTERP} PLAY_INTERP
  * @typedef {typeof import('./conventions/h-group/h-constants.js').DISCARD_INTERP} DISCARD_INTERP
  * @typedef {CLUE_INTERP[keyof CLUE_INTERP] | PLAY_INTERP[keyof PLAY_INTERP] | DISCARD_INTERP[keyof DISCARD_INTERP]} INTERP
@@ -26,7 +27,7 @@
  * @typedef {Clue & {urgent: boolean, trash: boolean}} FixClue
  */
 /**
- * @typedef {{focus: number, chop: boolean, positional: boolean}} FocusResult
+ * @typedef {{focus: number, chop: boolean, positional: boolean, focus_interp: FOCUS_INTERP[keyof FOCUS_INTERP]}} FocusResult
  * 
  * @typedef ClueResult
  * @property {number} focus

--- a/test/h-group/h-endgames.js
+++ b/test/h-group/h-endgames.js
@@ -22,7 +22,6 @@ describe('simple endgames with 1 card left', () => {
 			['r4', 'r1', 'g1', 'b1'],
 			['r4', 'p1', 'p1', 'b5'],
 		], {
-			level: { max: 13 },
 			play_stacks: [3, 4, 5, 4, 5],
 			discarded: [
 				'r2', 'r3',

--- a/test/h-group/h-endgames.js
+++ b/test/h-group/h-endgames.js
@@ -22,6 +22,7 @@ describe('simple endgames with 1 card left', () => {
 			['r4', 'r1', 'g1', 'b1'],
 			['r4', 'p1', 'p1', 'b5'],
 		], {
+			level: { max: 13 },
 			play_stacks: [3, 4, 5, 4, 5],
 			discarded: [
 				'r2', 'r3',

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -151,6 +151,7 @@ describe('interpreting trash push', () => {
 
 		// Bob's slot 2 should be finessed.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][1]].status, CARD_STATUS.FINESSED);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.BOB][1]], ['r2', 'g2', 'b2', 'y2', 'p2']);
 	});
 
 	it('will interpret a receiving a trash push', () => {
@@ -211,7 +212,7 @@ describe('interpreting trash finesse', () => {
 			['r1', 'p3', 'b4', 'g4'],
 		], {
 			level: { min: 14 },
-			play_stacks: [0, 1, 2, 0, 0],
+			play_stacks: [0, 1, 2, 1, 1],
 		});
 		takeTurn(game, 'Alice clues 1 to Bob');
 
@@ -282,7 +283,7 @@ describe('interpreting trash finesse', () => {
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['r1', 'y1', 'g1', 'b1', 'p1']);
 	});
 
-	it('will interpret receiving a play when a possible reverse trash finesse is visible', async () => {
+	it('will interpret receiving a play when an ambiguous reverse trash finesse is visible', async () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx'],
 			['r1', 'p3', 'b4', 'g4'],

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -68,7 +68,7 @@ describe('giving trash order chop move', () => {
 
 });
 
-describe('interpreting touch order chop move', () => {
+describe('interpreting trash order chop move', () => {
 	it('will interpret a tocm to the next player', () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
@@ -101,6 +101,34 @@ describe('interpreting touch order chop move', () => {
 
 		// Alice's slot 5 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
+	});
+	it(`shouldn't confuse a scream discard for a tocm`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['b4', 'b5', 'g2', 'r3', 'r5'],
+			['y1', 'r4', 'g4', 'r4', 'y3']
+		], {
+			level: { min: 14 },
+			starting: PLAYER.BOB,
+			play_stacks: [1, 0, 0, 0, 0],
+			clue_tokens: 1
+		});
+
+		takeTurn(game, 'Bob clues 1 to Alice (slot 4)');
+		takeTurn(game, 'Cathy plays y1', 'r2');
+
+		// Alice's slot 5 should be chop moved from the trash finesse.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
+		// Alice's slot 4 should be known trash.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].trash, true);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]], ['r1']);
+
+		// If Alice discards slot 3 with known trash on zero clues, must intend an SDCM.
+		takeTurn(game, 'Alice discards p4 (slot 3)');
+
+		// Bob is chop moved once from the scream discard.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][3]].status, undefined);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][4]].status, CARD_STATUS.CM);
 	});
 });
 
@@ -668,6 +696,25 @@ describe('interpreting trash finesse', () => {
 
 		// No blind play expected as there is only one useful red card.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].blind_playing, false);
+	});
+
+	it(`shouldn't interpret a trash finesse if the card could already be blind playing`, async () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g2', 'g5', 'g3', 'y1', 'p3'],
+			['r2', 'y3', 'r5', 'y4', 'r4']
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 0, 0, 1, 0],
+			starting: PLAYER.BOB,
+		});
+		takeTurn(game, 'Bob clues 3 to Alice (slot 5)');
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].blind_playing, true);
+
+		takeTurn(game, 'Cathy clues 1 to Bob (slot 4)');
+		// Since Alice was already going to play, this cannot be a trash finesse and should instead be interpreted as a play.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.BOB][3]], ['y1', 'g1', 'p1', 'r1']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][4]].status, undefined);
 	});
 });
 

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -934,7 +934,7 @@ describe('interpreting trash finesse', () => {
 		// Trash finesse on b4.
 		takeTurn(game, 'Cathy clues 4 to Bob');
 
-		// Since Donald was already going to play, this cannot be an trash finesse on Donald and should instead be on us.
+		// Since Donald already has a blind play, this cannot be a trash bluff and Alice must play [y4,p4] as a trash finesse.
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]], ['y4', 'p4']);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][2]].status, CARD_STATUS.CM);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][3]].status, CARD_STATUS.CM);

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -674,7 +674,7 @@ describe('interpreting trash finesse', () => {
 			['g4', 'y3', 'b3', 'p4'],
 		], {
 			level: { min: 14 },
-			play_stacks: [1, 2, 2, 0, 5],
+			play_stacks: [1, 2, 2, 3, 5],
 			starting: PLAYER.BOB,
 			init: (game) => {
 				game.state.early_game = false;
@@ -751,7 +751,7 @@ describe('interpreting trash finesse', () => {
 		// Trash finesse on b4.
 		takeTurn(game, 'Cathy clues 4 to Bob');
 
-		// Since Alice was already going to play, this cannot be an r4 trash finesse and should instead be interpreted as an immediate y4, p4.
+		// Since Donald was already going to play, this cannot be an trash finesse on Donald and should instead be on us.
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]], ['y4', 'p4']);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][2]].status, CARD_STATUS.CM);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][3]].status, CARD_STATUS.CM);
@@ -778,6 +778,51 @@ describe('interpreting trash finesse', () => {
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['b2']);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, undefined);
 	});
+
+	it(`doesn't keep playing after a trash finesse`, async () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['y4', 'p3', 'b4', 'g2', 'b3'],
+			['y5', 'g3', 'g4', 'r1', 'b3']
+		], {
+			level: { min: 14 },
+			play_stacks: [3, 0, 0, 0, 0],
+			discarded: ['r4'],
+			starting: PLAYER.BOB
+		});
+
+		takeTurn(game, 'Bob clues red to Cathy');
+		takeTurn(game, 'Cathy discards r1', 'p1');
+		takeTurn(game, 'Alice plays r4 (slot 1)');
+
+		// Alice shouldn't keep playing for r5.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][1]].status, undefined);
+	});
+
+	it(`understands a trash finesse where we may have the last playable identity`, async () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['y4', 'p3', 'b4', 'g2'],
+			['y5', 'g3', 'g4', 'r1'],
+			['r4', 'b3', 'b3', 'y4']
+		], {
+			level: { min: 14 },
+			play_stacks: [3, 0, 0, 0, 0],
+			discarded: ['r4'],
+			starting: PLAYER.BOB
+		});
+
+		takeTurn(game, 'Bob clues red to Cathy');
+
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].trash, true);
+
+		takeTurn(game, 'Cathy discards r1', 'p1');
+		takeTurn(game, 'Donald plays r4', 'g5');
+
+		// Alice shouldn't keep playing for r5.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].status, undefined);
+	});
+
 });
 
 describe('giving trash finesses', () => {

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -109,7 +109,7 @@ describe('giving trash order chop move', () => {
 		const { play_clues, save_clues, fix_clues, stall_clues } = find_clues(game);
 		const urgent_actions = find_urgent_actions(game, play_clues, save_clues, fix_clues, stall_clues, playable_priorities);
 		// Alice has known trash, but should signal to Bob that he cannot discard his chop.
-		ExAsserts.objHasProperties(urgent_actions[ACTION_PRIORITY.ONLY_SAVE][0], { type: ACTION.DISCARD, target: our_hand[2] });
+		ExAsserts.objHasProperties(urgent_actions[ACTION_PRIORITY.PLAY_OVER_SAVE][0], { type: ACTION.DISCARD, target: our_hand[2] });
 	});
 
 });

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -213,6 +213,40 @@ describe('interpreting trash push', () => {
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].status, CARD_STATUS.F_MAYBE_BLUFF);
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]], ['r3']);
 	});
+
+	it('understands a trash push must be playable by its turn', () => {
+		// Based on https://hanab.live/replay/1797088#26
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['y3', 'p1', 'g1', 'y2'],
+			['p1', 'r2', 'g4', 'g1'],
+			['b2', 'r1', 'p3', 'y3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [4, 1, 5, 1, 5],
+			starting: PLAYER.CATHY,
+			init: (game) => {
+				game.state.early_game = false;
+
+				// Donald's b2 is known.
+				preClue(game, game.state.hands[PLAYER.DONALD][0], [
+					{ type: CLUE.RANK, value: 2, giver: PLAYER.ALICE }
+				]);
+				// Donald's y3 is known.
+				preClue(game, game.state.hands[PLAYER.DONALD][3], [
+					{ type: CLUE.COLOUR, value: COLOUR.YELLOW, giver: PLAYER.BOB }
+				]);
+				// Bob's y2 is known.
+				preClue(game, game.state.hands[PLAYER.BOB][3], [
+					{ type: CLUE.RANK, value: 2, giver: PLAYER.ALICE }
+				]);
+			}
+		});
+		takeTurn(game, 'Cathy clues 1 to Alice (slot 4)');
+		// Alice's slot 3 should be finessed as r5,b3, but not y4 as that cannot be playable on time.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]].status, CARD_STATUS.FINESSED);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['r5', 'b3']);
+	});
 });
 
 describe('interpreting trash finesse', () => {
@@ -855,6 +889,34 @@ describe('interpreting trash finesse', () => {
 		assert.ok(!play_clues[PLAYER.CATHY].some(clue => clue.type === CLUE.RANK && clue.value === 2));
 	});
 
+	it(`understands a trash finesse where giver knows they have the last id`, async () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['r4', 'g1', 'r1', 'b3'],
+			['p4', 'p3', 'p5', 'p3'],
+			['b1', 'g5', 'r1', 'r5']
+		], {
+			level: { min: 14 },
+			play_stacks: [3, 3, 3, 0, 0],
+			init: (game) => {
+				game.state.early_game = false;
+
+				// Donald knows they have r5.
+				preClue(game, game.state.hands[PLAYER.DONALD][3], [
+					{ type: CLUE.RANK, value: 5, giver: PLAYER.BOB },
+					{ type: CLUE.COLOUR, value: COLOUR.RED, giver: PLAYER.CATHY }
+				]);
+			},
+			starting: PLAYER.DONALD
+		});
+
+		// Donald knows they have r5, so Alice should still recognize this as a trash finesse.
+		takeTurn(game, 'Donald clues red to Alice (slot 3)');
+
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing, true);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]].trash, true);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+	});
 });
 
 describe('giving trash finesses', () => {

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -281,6 +281,14 @@ describe('interpreting trash finesse', () => {
 
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['r1', 'y1', 'g1', 'b1', 'p1']);
+
+		// Alice should discard her slot 3 to show that the finesse is recognized.
+		const action = await game.take_action();
+		ExAsserts.objHasProperties(action, { type: ACTION.DISCARD, target: game.state.hands[PLAYER.ALICE][2] });
+		takeTurn(game, 'Alice discards r1 (slot 3)');
+
+		// After the discard, slot 4 is still chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
 	});
 
 	it('will interpret receiving a play when an ambiguous reverse trash finesse is visible', async () => {

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -342,6 +342,33 @@ describe('interpreting trash finesse', () => {
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
 	});
 
+	it(`will interpret receiving a colour play when possible trash bluff isn't played`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['y5', 'g2', 'p4', 'p2', 'g1'],
+			['r1', 'b3', 'p1', 'g4', 'b3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 4, 0, 0],
+			starting: PLAYER.BOB,
+		});
+		takeTurn(game, 'Bob clues green to Alice (slot 3)');
+
+		// Cathy's slot 1 should be blind played.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.MAYBE_BLUFFED);
+		// Alice's slots 4 and 5 should be chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
+
+		takeTurn(game, 'Cathy discards b3 (slot 5)', 'p5');
+
+		// Alice has a direct play.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['g5']);
+		// Alice's is no longer chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, undefined);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, undefined);
+	});
+
 	it('will interpret receiving an ambiguous rank direct play', () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -215,7 +215,7 @@ describe('interpreting trash push', () => {
 	});
 
 	it('understands a trash push must be playable by its turn', () => {
-		// Based on https://hanab.live/replay/1797088#26
+		// Based on https://hanab.live/replay/1797088#52
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx'],
 			['y3', 'p1', 'g1', 'y2'],
@@ -246,6 +246,75 @@ describe('interpreting trash push', () => {
 		// Alice's slot 3 should be finessed as r5,b3, but not y4 as that cannot be playable on time.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]].status, CARD_STATUS.FINESSED);
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['r5', 'b3']);
+	});
+
+	it(`understands others must make trash push playable by our turn`, async () => {
+		// Based on https://hanab.live/replay/1797088#52
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['p1', 'r2', 'g4', 'g1', 'p1'],
+			['b2', 'r1', 'p3', 'y3', 'g1'],
+		], {
+			level: { min: 14 },
+			play_stacks: [4, 2, 5, 1, 5],
+			starting: PLAYER.BOB,
+			init: (game) => {
+				game.state.early_game = false;
+
+				// Cathy's b2 is known.
+				preClue(game, game.state.hands[PLAYER.CATHY][0], [
+					{ type: CLUE.RANK, value: 2, giver: PLAYER.ALICE }
+				]);
+				// Cathy's y3 is known.
+				preClue(game, game.state.hands[PLAYER.CATHY][3], [
+					{ type: CLUE.COLOUR, value: COLOUR.YELLOW, giver: PLAYER.BOB }
+				]);
+			}
+		});
+		takeTurn(game, 'Bob clues 1 to Alice (slot 5)');
+		// Alice's slot 4 should be finessed as r5,b3,y4.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.FINESSED);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]], ['r5', 'y4', 'b3']);
+
+		takeTurn(game, 'Cathy plays y3', 'y5');
+
+		// Alice should play her pushed card.
+		const action = await game.take_action();
+		ExAsserts.objHasProperties(action, { type: ACTION.PLAY, target: game.state.hands[PLAYER.ALICE][3] });
+		takeTurn(game, 'Alice plays y4 (slot 3)');
+	});
+
+	it(`understands it must make trash push playable by target's turn`, async () => {
+		// Based on https://hanab.live/replay/1797088#52
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['b4', 'b5', 'r5', 'y4', 'p1'],
+			['r1', 'r2', 'g4', 'g1', 'p1'],
+		], {
+			level: { min: 14 },
+			play_stacks: [4, 2, 5, 1, 5],
+			starting: PLAYER.CATHY,
+			init: (game) => {
+				game.state.early_game = false;
+
+				// Alice has a 2.
+				preClue(game, game.state.hands[PLAYER.ALICE][0], [
+					{ type: CLUE.RANK, value: 2, giver: PLAYER.BOB }
+				]);
+				// Alice has a 3.
+				preClue(game, game.state.hands[PLAYER.ALICE][3], [
+					{ type: CLUE.RANK, value: 3, giver: PLAYER.BOB }
+				]);
+			}
+		});
+		takeTurn(game, 'Cathy clues 1 to Bob');
+		// Bob's slot 4 should be finessed.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][3]].status, CARD_STATUS.FINESSED);
+
+		// Alice should play the connecting card.
+		const action = await game.take_action();
+		ExAsserts.objHasProperties(action, { type: ACTION.PLAY, target: game.state.hands[PLAYER.ALICE][3] });
+		takeTurn(game, 'Alice plays y3 (slot 3)');
 	});
 });
 

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -171,7 +171,7 @@ describe('interpreting trash push', () => {
 });
 
 describe('interpreting trash finesse', () => {
-	it('will interpret a trash finesse', () => {
+	it('will interpret a rank trash finesse', () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['r1', 'p3', 'b4', 'g4', 'g1'],
@@ -188,7 +188,27 @@ describe('interpreting trash finesse', () => {
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, CARD_STATUS.CM);
 	});
 
-	it('will interpret an ambiguous direct play', () => {
+	it('will interpret a colour trash finesse', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r1', 'p3', 'b4', 'g4', 'g1'],
+			['y1', 'g2', 'y5', 'p2', 'b3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 4, 0, 0],
+		});
+		// The clue looks like Alice is telling Cathy to play g5.
+		// If Bob plays slot 1, it will prove that Alice's clued card was in fact trash, and
+		// saves several useful cards in cathy's hand.
+		takeTurn(game, 'Alice clues green to Cathy');
+
+		// Bob's slot 1 should be blind played.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing, true);
+		// Cathy's slot 4 should be chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, CARD_STATUS.CM);
+	});
+
+	it('will interpret an ambiguous rank direct play', () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['r1', 'p3', 'b4', 'g4', 'g1'],
@@ -198,14 +218,31 @@ describe('interpreting trash finesse', () => {
 			play_stacks: [0, 1, 2, 0, 0],
 		});
 		takeTurn(game, 'Alice clues 1 to Cathy');
-		takeTurn(game, 'Bob discards g4', 'p3');
+		takeTurn(game, 'Bob discards g1', 'p3');
 
 		// Cathy's slot 3 should be assumed playable.
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.CATHY][2]], ['r1', 'b1', 'p1']);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, undefined);
 	});
 
-	it('will interpret a reverse trash finesse', () => {
+	it('will interpret an ambiguous colour direct play', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r1', 'p3', 'b4', 'g4', 'g1'],
+			['y5', 'g5', 'b1', 'p2', 'b3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 4, 0, 0],
+		});
+		takeTurn(game, 'Alice clues green to Cathy');
+		takeTurn(game, 'Bob discards g1', 'p3');
+
+		// Cathy's slot 2 should be assumed playable.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.CATHY][1]], ['g5']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, undefined);
+	});
+
+	it('will interpret a reverse rank trash finesse', () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['y5', 'g2', 'g1', 'p2', 'b3'],
@@ -218,11 +255,30 @@ describe('interpreting trash finesse', () => {
 
 		// Cathy's slot 1 should be finessed.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.FINESSED);
-		// Bob's slot 4 should be chop moved.
+		// Bob's slots 4 and 5 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][3]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][4]].status, CARD_STATUS.CM);
 	});
 
-	it('will interpret receiving a trash finesse', () => {
+	it('will interpret a reverse colour trash finesse', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['y5', 'b1', 'g2', 'p2', 'b3'],
+			['g5', 'p3', 'b4', 'g4', 'g1'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 4, 1, 1],
+		});
+		takeTurn(game, 'Alice clues green to Bob');
+
+		// Cathy's slot 1 should be finessed.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.FINESSED);
+		// Bob's slots 4 and 5 should be chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][3]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][4]].status, CARD_STATUS.CM);
+	});
+
+	it('will interpret receiving a rank trash finesse', () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['y5', 'g2', 'g4', 'p2', 'g1'],
@@ -238,9 +294,55 @@ describe('interpreting trash finesse', () => {
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.MAYBE_BLUFFED);
 		// Alice's slot 4 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
 	});
 
-	it('will interpret receiving an ambiguous direct play', () => {
+	it('will interpret receiving a colour trash finesse', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['y5', 'g2', 'p4', 'p2', 'g1'],
+			['g5', 'p3', 'b4', 'g4', 'b3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 4, 0, 0],
+			starting: PLAYER.BOB,
+		});
+		takeTurn(game, 'Bob clues green to Alice (slot 3)');
+
+		// Cathy's slot 1 should be blind played.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.FINESSED);
+		// Alice's slots 4 and 5 should be chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
+	});
+
+	it('will interpret receiving a colour trash bluff', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['y5', 'g2', 'p4', 'p2', 'g1'],
+			['r1', 'p3', 'b4', 'g4', 'b3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 4, 0, 0],
+			starting: PLAYER.BOB,
+		});
+		takeTurn(game, 'Bob clues green to Alice (slot 3)');
+
+		// Cathy's slot 1 should be blind played.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.MAYBE_BLUFFED);
+		// Alice's slots 4 and 5 should be chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
+
+		takeTurn(game, 'Cathy plays r1', 'b5');
+
+		// Alice's slot 2 must be known trash.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['g1', 'g2', 'g3', 'g4']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
+	});
+
+	it('will interpret receiving an ambiguous rank direct play', () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['y5', 'g2', 'g4', 'p2', 'g1'],
@@ -254,8 +356,9 @@ describe('interpreting trash finesse', () => {
 
 		// Cathy's slot 1 is expected to blind play.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.MAYBE_BLUFFED);
-		// Alice's slot 4 should be chop moved.
+		// Alice's slots 4 and 5 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
 
 		takeTurn(game, 'Cathy discards g4', 'p3');
 
@@ -265,7 +368,7 @@ describe('interpreting trash finesse', () => {
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, undefined);
 	});
 
-	it('will interpret receiving a reverse trash finesse', async () => {
+	it('will interpret receiving a reverse rank trash finesse', async () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['r1', 'p3', 'b4', 'g4', 'b3'],
@@ -293,7 +396,34 @@ describe('interpreting trash finesse', () => {
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
 	});
 
-	it('will interpret receiving a play when an ambiguous reverse trash finesse is visible', async () => {
+	it('will interpret receiving a reverse colour trash finesse', async () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g4', 'p3', 'b4', 'g4', 'b3'],
+			['y5', 'g2', 'y4', 'p3', 'g1'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 3, 1, 1],
+			starting: PLAYER.BOB,
+		});
+		takeTurn(game, 'Bob clues 5 to Alice (slot 5)');
+		// Alice can see that the identity of the promised play matches Bob's g4.
+		// She should treat it as a reverse trash finesse and chop move her slot 4.
+		takeTurn(game, 'Cathy clues green to Alice (slot 3)');
+
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['g1', 'g2', 'g3', 'g4']);
+
+		// Alice should discard her slot 3 to show that the finesse is recognized.
+		const action = await game.take_action();
+		ExAsserts.objHasProperties(action, { type: ACTION.DISCARD, target: game.state.hands[PLAYER.ALICE][2] });
+		takeTurn(game, 'Alice discards g4 (slot 3)');
+
+		// After the discard, slot 4 is still chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+	});
+
+	it('will interpret receiving a play when an ambiguous reverse rank trash finesse is visible', async () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['r1', 'p3', 'b4', 'g4', 'b3'],

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -184,8 +184,29 @@ describe('interpreting trash finesse', () => {
 
 		// Bob's slot 1 should be blind played.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing, true);
-		// Cathy's slot 4 should be chop moved.
+		// Cathy's slots 4 and 5 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][4]].status, CARD_STATUS.CM);
+	});
+
+	it('will interpret a rank trash finesse touching multiple cards', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r1', 'p3', 'b4', 'g4', 'g1'],
+			['y5', 'g2', 'g1', 'y1', 'b3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 2, 0, 0],
+		});
+		takeTurn(game, 'Alice clues 1 to Cathy');
+
+		// Bob's slot 1 should be blind played.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing, true);
+		// Both touched cards are marked as trash.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][2]].trash, true);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].trash, true);
+		// Cathy's slot 5 should be chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][4]].status, CARD_STATUS.CM);
 	});
 
 	it('will interpret a colour trash finesse', () => {
@@ -294,6 +315,27 @@ describe('interpreting trash finesse', () => {
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.MAYBE_BLUFFED);
 		// Alice's slot 4 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
+	});
+
+	it('will interpret receiving a rank trash finesse touching multiple cards', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['y5', 'g2', 'g4', 'p2', 'g1'],
+			['r1', 'p3', 'b4', 'g4', 'b3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 2, 0, 0],
+			starting: PLAYER.BOB,
+		});
+		takeTurn(game, 'Bob clues 1 to Alice (slots 3,4)');
+
+		// Cathy's slot 1 should be blind played.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.MAYBE_BLUFFED);
+		// Alice's slot 3 and 4 are known trash
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]].trash, true);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].trash, true);
+		// Alice's slot 5 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
 	});
 
@@ -485,9 +527,13 @@ describe('interpreting trash finesse', () => {
 		takeTurn(game, 'Alice clues red to Cathy');
 		// Bob's slot 1 should be blind played.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing, true);
+		// Cathy's slot 2 is known trash
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][1]].trash, true);
 		// Cathy's slots 3 and 4 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][2]].status, CARD_STATUS.CM);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, CARD_STATUS.CM);
+		// Cathy's slot 5 is not trash
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][4]].trash, false);
 
 		takeTurn(game, 'Bob plays r4', 'g2');
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.CATHY][1]], ['r1', 'r2', 'r3']);

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -508,13 +508,17 @@ describe('interpreting trash finesse', () => {
 
 		// Alice's slot 1 should be r1 blind playing.
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]], ['r1', 'y2', 'g2', 'b2', 'p2']);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.BOB][3]], ['y1', 'g1', 'b1', 'p1']);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].blind_playing, true);
 
 		// Bob's slots 5 is chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][4]].status, CARD_STATUS.CM);
+		const action = await game.take_action();
+		ExAsserts.objHasProperties(action, { type: ACTION.PLAY, target: game.state.hands[PLAYER.ALICE][0] });
 		takeTurn(game, 'Alice plays g2 (slot 1)');
 
 		// Bob is still chop moved.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.BOB][3]], ['y1', 'g1', 'b1', 'p1']);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][4]].status, CARD_STATUS.CM);
 	});
 });

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -173,9 +173,9 @@ describe('interpreting trash push', () => {
 describe('interpreting trash finesse', () => {
 	it('will interpret a trash finesse', () => {
 		const game = setup(HGroup, [
-			['xx', 'xx', 'xx', 'xx'],
-			['r1', 'p3', 'b4', 'g4'],
-			['y5', 'g2', 'g1', 'p2'],
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r1', 'p3', 'b4', 'g4', 'g1'],
+			['y5', 'g2', 'g1', 'p2', 'b3'],
 		], {
 			level: { min: 14 },
 			play_stacks: [0, 1, 2, 0, 0],
@@ -190,9 +190,9 @@ describe('interpreting trash finesse', () => {
 
 	it('will interpret an ambiguous direct play', () => {
 		const game = setup(HGroup, [
-			['xx', 'xx', 'xx', 'xx'],
-			['r1', 'p3', 'b4', 'g4'],
-			['y5', 'g2', 'b1', 'p2'],
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r1', 'p3', 'b4', 'g4', 'g1'],
+			['y5', 'g2', 'b1', 'p2', 'b3'],
 		], {
 			level: { min: 14 },
 			play_stacks: [0, 1, 2, 0, 0],
@@ -207,9 +207,9 @@ describe('interpreting trash finesse', () => {
 
 	it('will interpret a reverse trash finesse', () => {
 		const game = setup(HGroup, [
-			['xx', 'xx', 'xx', 'xx'],
-			['y5', 'g2', 'g1', 'p2'],
-			['r1', 'p3', 'b4', 'g4'],
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['y5', 'g2', 'g1', 'p2', 'b3'],
+			['r1', 'p3', 'b4', 'g4', 'g1'],
 		], {
 			level: { min: 14 },
 			play_stacks: [0, 1, 2, 1, 1],
@@ -224,9 +224,9 @@ describe('interpreting trash finesse', () => {
 
 	it('will interpret receiving a trash finesse', () => {
 		const game = setup(HGroup, [
-			['xx', 'xx', 'xx', 'xx'],
-			['y5', 'g2', 'g4', 'p2'],
-			['r1', 'p3', 'b4', 'g4'],
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['y5', 'g2', 'g4', 'p2', 'g1'],
+			['r1', 'p3', 'b4', 'g4', 'b3'],
 		], {
 			level: { min: 14 },
 			play_stacks: [0, 1, 2, 0, 0],
@@ -242,9 +242,9 @@ describe('interpreting trash finesse', () => {
 
 	it('will interpret receiving an ambiguous direct play', () => {
 		const game = setup(HGroup, [
-			['xx', 'xx', 'xx', 'xx'],
-			['y5', 'g2', 'g4', 'p2'],
-			['r1', 'p3', 'b4', 'g4'],
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['y5', 'g2', 'g4', 'p2', 'g1'],
+			['r1', 'p3', 'b4', 'g4', 'b3'],
 		], {
 			level: { min: 14 },
 			play_stacks: [0, 1, 2, 0, 0],
@@ -267,19 +267,20 @@ describe('interpreting trash finesse', () => {
 
 	it('will interpret receiving a reverse trash finesse', async () => {
 		const game = setup(HGroup, [
-			['xx', 'xx', 'xx', 'xx'],
-			['r1', 'p3', 'b4', 'g4'],
-			['y5', 'g2', 'g4', 'p3'],
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r1', 'p3', 'b4', 'g4', 'b3'],
+			['y5', 'g2', 'g4', 'p3', 'g1'],
 		], {
 			level: { min: 14 },
 			play_stacks: [0, 1, 2, 1, 1],
 			starting: PLAYER.CATHY,
 		});
 		// Alice can see that the identity of the promised play matches Bob's r1.
-		// She should treat it as a reverse trash finesse and chop move her slot 4.
+		// She should treat it as a reverse trash finesse and chop move her slots 4 and 5.
 		takeTurn(game, 'Cathy clues 1 to Alice (slot 3)');
 
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['r1', 'y1', 'g1', 'b1', 'p1']);
 
 		// Alice should discard her slot 3 to show that the finesse is recognized.
@@ -287,15 +288,16 @@ describe('interpreting trash finesse', () => {
 		ExAsserts.objHasProperties(action, { type: ACTION.DISCARD, target: game.state.hands[PLAYER.ALICE][2] });
 		takeTurn(game, 'Alice discards r1 (slot 3)');
 
-		// After the discard, slot 4 is still chop moved.
+		// After the discard, slots 4 and 5 are still chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
 	});
 
 	it('will interpret receiving a play when an ambiguous reverse trash finesse is visible', async () => {
 		const game = setup(HGroup, [
-			['xx', 'xx', 'xx', 'xx'],
-			['r1', 'p3', 'b4', 'g4'],
-			['y5', 'g2', 'g4', 'p3'],
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r1', 'p3', 'b4', 'g4', 'b3'],
+			['y5', 'g2', 'g4', 'p3', 'g1'],
 		], {
 			level: { min: 14 },
 			play_stacks: [0, 1, 2, 0, 0],

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -840,6 +840,21 @@ describe('interpreting trash finesse', () => {
 
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].status, CARD_STATUS.FINESSED);
 	});
+
+	it(`won't chop move trash`, async () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['p2', 'p2', 'g1', 'r1', 'r1'],
+			['p4', 'y5', 'b4', 'r2', 'y1']
+		], {
+			level: { min: 14 },
+			play_stacks: [3, 3, 3, 3, 1]
+		});
+
+		const { play_clues } = find_clues(game);
+		assert.ok(!play_clues[PLAYER.CATHY].some(clue => clue.type === CLUE.RANK && clue.value === 2));
+	});
+
 });
 
 describe('giving trash finesses', () => {

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -1,13 +1,13 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { PLAYER, setup, takeTurn } from '../test-utils.js';
+import { COLOUR, PLAYER, setup, takeTurn } from '../test-utils.js';
 import * as ExAsserts from '../extra-asserts.js';
 import HGroup from '../../src/conventions/h-group.js';
 import { CARD_STATUS } from '../../src/basics/Card.js';
 
 import logger from '../../src/tools/logger.js';
-import { ACTION } from '../../src/constants.js';
+import { ACTION, CLUE } from '../../src/constants.js';
 import { find_clues } from '../../src/conventions/h-group/clue-finder/clue-finder.js';
 import { determine_playable_card } from '../../src/conventions/h-group/action-helper.js';
 import { find_urgent_actions } from '../../src/conventions/h-group/urgent-actions.js';
@@ -441,4 +441,96 @@ describe('interpreting trash finesse', () => {
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['r1', 'b1', 'p1']);
 	});
 
+	it('interprets a fill-in trash finesse', async() => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r4', 'b4', 'r1', 'b3', 'g4'],
+			['y2', 'r1', 'g4', 'b3', 'r5'],
+		], {
+			level: { min: 14 },
+			play_stacks: [3, 0, 0, 0, 0],
+			starting: PLAYER.BOB,
+		});
+		takeTurn(game, 'Bob clues 5 to Cathy');
+		takeTurn(game, 'Cathy clues 5 to Alice (slot 5)');
+
+		// This fills in the r5 and clues the r1 as a play.
+		takeTurn(game, 'Alice clues red to Cathy');
+		// Bob's slot 1 should be blind played.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing, true);
+		// Cathy's slots 3 and 4 should be chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][2]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, CARD_STATUS.CM);
+
+		takeTurn(game, 'Bob plays r4', 'g2');
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.CATHY][1]], ['r1', 'r2', 'r3']);
+		// Cathy's slots 3 and 4 remain chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][2]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, CARD_STATUS.CM);
+	});
+
+	it('interprets receiving a reverse trash finesse', async() => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r4', 'b4', 'r1', 'b3', 'g4'],
+			['y3', 'g3', 'g4', 'b1', 'r5'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 1, 1, 1],
+			starting: PLAYER.BOB,
+		});
+		takeTurn(game, 'Bob clues 1 to Cathy');
+		takeTurn(game, 'Cathy discards b1', 'y3');
+
+		// Alice's slot 1 should be r1 blind playing.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]], ['r1']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].blind_playing, true);
+
+		// Cathy's slots 5 is chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][4]].status, CARD_STATUS.CM);
+		takeTurn(game, 'Alice plays r1 (slot 1)');
+
+		// Cathy is still chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][4]].status, CARD_STATUS.CM);
+	});
+
+	it('interprets receiving a trash bluff', async() => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['y3', 'g3', 'g4', 'b1', 'r5'],
+			['r4', 'b4', 'r1', 'b3', 'g4'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 1, 1, 1],
+			starting: PLAYER.CATHY,
+		});
+		takeTurn(game, 'Cathy clues 1 to Bob');
+
+		// Alice's slot 1 should be r1 blind playing.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]], ['r1', 'y2', 'g2', 'b2', 'p2']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].blind_playing, true);
+
+		// Bob's slots 5 is chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][4]].status, CARD_STATUS.CM);
+		takeTurn(game, 'Alice plays g2 (slot 1)');
+
+		// Bob is still chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][4]].status, CARD_STATUS.CM);
+	});
+});
+
+describe('giving trash finesses', () => {
+	it(`won't give a bad trash finesse`, async () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r4', 'p3', 'b4', 'g2', 'b3'],
+			['y5', 'g3', 'g4', 'r1', 'b3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [3, 0, 0, 0, 0]
+		});
+		const { play_clues } = find_clues(game);
+		// Red to Cathy is not a valid clue as Cathy will think it is r5.
+		assert.ok(!play_clues[PLAYER.CATHY].some(clue => clue.type === CLUE.COLOUR && clue.value === COLOUR.RED));
+	});
 });

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -1,7 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { COLOUR, PLAYER, setup, takeTurn } from '../test-utils.js';
+import { COLOUR, PLAYER, preClue, setup, takeTurn } from '../test-utils.js';
 import * as ExAsserts from '../extra-asserts.js';
 import HGroup from '../../src/conventions/h-group.js';
 import { CARD_STATUS } from '../../src/basics/Card.js';
@@ -547,6 +547,37 @@ describe('interpreting trash finesse', () => {
 		// Bob is still chop moved.
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.BOB][3]], ['y1', 'g1', 'b1', 'p1']);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][4]].status, CARD_STATUS.CM);
+	});
+
+	describe('recognizes real prompt over false trash finesse', async () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['b1', 'g1', 'r5', 'r4'],
+			['g3', 'r2', 'y1', 'g4'],
+			['g4', 'y3', 'b3', 'p4'],
+		], {
+			level: { min: 14 },
+			play_stacks: [1, 2, 2, 0, 5],
+			starting: PLAYER.BOB,
+			init: (game) => {
+				game.state.early_game = false;
+
+				// Cathy's r1 is known.
+				preClue(game, game.state.hands[PLAYER.CATHY][1], [
+					{ type: CLUE.RANK, value: 2, giver: PLAYER.ALICE }
+				]);
+			}
+		});
+		takeTurn(game, 'Bob clues 3 to Alice (slot 2)');
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+
+		takeTurn(game, 'Cathy plays r2', 'g5');
+
+		// After cathy doesn't play possible trash bluff, we are no longer chop moved and can infer regular connections.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][1]], ['r3', 'y3', 'g3']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]].status, undefined);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, undefined);
 	});
 });
 

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -798,7 +798,7 @@ describe('interpreting trash finesse', () => {
 			init: (game) => {
 				game.state.early_game = false;
 
-				// Cathy's r1 is known.
+				// Cathy's r2 is known.
 				preClue(game, game.state.hands[PLAYER.CATHY][1], [
 					{ type: CLUE.RANK, value: 2, giver: PLAYER.ALICE }
 				]);
@@ -988,6 +988,26 @@ describe('interpreting trash finesse', () => {
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]].trash, true);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
 	});
+
+	it(`prefers a bluff over a trash bluff`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g2', 'b3', 'r4', 'p3', 'r1'],
+			['r4', 'p2', 'g4', 'y5', 'y1']
+		], {
+			play_stacks: [3, 4, 2, 2, 2],
+			level: { min: 14 },
+			clue_tokens: 4,
+			starting: PLAYER.BOB
+		});
+
+		takeTurn(game, 'Bob clues 4 to Alice (slot 4)');
+		takeTurn(game, 'Cathy plays r4', 'y2');
+
+		// Cathy would need to discharge to prove trash.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]], ['g4', 'b4', 'p4']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, undefined);
+	});
 });
 
 describe('giving trash finesses', () => {
@@ -1033,7 +1053,8 @@ describe('giving trash finesses', () => {
 		// Bob knows about his 2's
 		takeTurn(game, 'Cathy clues 2 to Bob');
 
-		// Alice should not clue 2 to Bob - cluing an already clued card is not a trash push.
+		// Alice should not clue 2 to Bob - Bob needs to play to allow Cathy's play but would
+		// need to see if Cathy plays to know if it is in fact a trash finesse.
 		const { play_clues } = find_clues(game);
 		assert.ok(!play_clues[PLAYER.BOB].some(clue => clue.type === CLUE.RANK && clue.value === 2));
 	});

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -166,7 +166,7 @@ describe('interpreting trash order chop move', () => {
 		// Alice's slot 5 should be chop moved from the trash finesse.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
 		// Alice's slot 4 should be known trash.
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].trash, true);
+		assert(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].trash);
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]], ['r1']);
 
 		// If Alice discards slot 3 with known trash on zero clues, must intend an SDCM.
@@ -393,7 +393,7 @@ describe('interpreting trash finesse', () => {
 		takeTurn(game, 'Alice clues 1 to Cathy');
 
 		// Bob's slot 1 should be blind played.
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing, true);
+		assert(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing);
 		// Cathy's slots 4 and 5 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, CARD_STATUS.CM);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][4]].status, CARD_STATUS.CM);
@@ -411,10 +411,10 @@ describe('interpreting trash finesse', () => {
 		takeTurn(game, 'Alice clues 1 to Cathy');
 
 		// Bob's slot 1 should be blind played.
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing, true);
+		assert(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing);
 		// Both touched cards are marked as trash.
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][2]].trash, true);
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].trash, true);
+		assert(game.common.thoughts[game.state.hands[PLAYER.CATHY][2]].trash);
+		assert(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].trash);
 		// Cathy's slot 5 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][4]].status, CARD_STATUS.CM);
 	});
@@ -438,7 +438,7 @@ describe('interpreting trash finesse', () => {
 		takeTurn(game, 'Alice clues green to Cathy');
 
 		// Bob's slot 1 should be blind played.
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing, true);
+		assert(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing);
 		// Cathy's slot 4 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, CARD_STATUS.CM);
 	});
@@ -468,11 +468,8 @@ describe('interpreting trash finesse', () => {
 		], {
 			level: { min: 14 },
 			play_stacks: [0, 1, 3, 0, 0],
-			starting: PLAYER.BOB,
+			starting: PLAYER.ALICE,
 		});
-		takeTurn(game, 'Bob clues 5 to Cathy');
-		takeTurn(game, 'Cathy clues 5 to Alice (slot 5)');
-
 		takeTurn(game, 'Alice clues green to Cathy');
 		takeTurn(game, 'Bob discards g1', 'p3');
 
@@ -568,8 +565,8 @@ describe('interpreting trash finesse', () => {
 		// Cathy's slot 1 should be blind played.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.MAYBE_BLUFFED);
 		// Alice's slot 3 and 4 are known trash
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]].trash, true);
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].trash, true);
+		assert(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]].trash);
+		assert(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].trash);
 		// Alice's slot 5 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
 	});
@@ -615,7 +612,7 @@ describe('interpreting trash finesse', () => {
 
 		takeTurn(game, 'Cathy plays r1', 'b5');
 
-		// Alice's slot 2 must be known trash.
+		// Alice's slot 3 must be known trash.
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['g1', 'g2', 'g3']);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
 	});
@@ -643,7 +640,7 @@ describe('interpreting trash finesse', () => {
 
 		// Alice has a direct play.
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['g4']);
-		// Alice's is no longer chop moved.
+		// Alice is no longer chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, undefined);
 	});
 
@@ -699,6 +696,7 @@ describe('interpreting trash finesse', () => {
 		// After the discard, slots 4 and 5 are still chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
+		assert(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing);
 	});
 
 	it('will interpret receiving a reverse colour trash finesse', async () => {
@@ -722,10 +720,11 @@ describe('interpreting trash finesse', () => {
 		// Alice should discard her slot 3 to show that the finesse is recognized.
 		const action = await game.take_action();
 		ExAsserts.objHasProperties(action, { type: ACTION.DISCARD, target: game.state.hands[PLAYER.ALICE][2] });
-		takeTurn(game, 'Alice discards g4 (slot 3)');
+		takeTurn(game, 'Alice discards g1 (slot 3)');
 
 		// After the discard, slot 4 is still chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+		assert(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing);
 	});
 
 	it('will interpret receiving a play when an ambiguous reverse rank trash finesse is visible', async () => {
@@ -762,9 +761,9 @@ describe('interpreting trash finesse', () => {
 		// This fills in the r5 and clues the r1 as a play.
 		takeTurn(game, 'Alice clues red to Cathy');
 		// Bob's slot 1 should be blind played.
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing, true);
+		assert(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing);
 		// Cathy's slot 2 is known trash
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][1]].trash, true);
+		assert(game.common.thoughts[game.state.hands[PLAYER.CATHY][1]].trash);
 		// Cathy's slots 3 and 4 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][2]].status, CARD_STATUS.CM);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, CARD_STATUS.CM);
@@ -793,7 +792,7 @@ describe('interpreting trash finesse', () => {
 
 		// Alice's slot 1 should be r1 blind playing.
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]], ['r1']);
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].blind_playing, true);
+		assert(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].blind_playing);
 
 		// Cathy's slots 5 is chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][4]].status, CARD_STATUS.CM);
@@ -818,9 +817,9 @@ describe('interpreting trash finesse', () => {
 		// Alice's slot 1 should be r1 blind playing.
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]], ['r1', 'y2', 'g2', 'b2', 'p2']);
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.BOB][3]], ['r1', 'y1', 'g1', 'b1', 'p1']);
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].blind_playing, true);
+		assert(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].blind_playing);
 
-		// Bob's slots 5 is chop moved.
+		// Bob's slot 5 is chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][4]].status, CARD_STATUS.CM);
 		const action = await game.take_action();
 		ExAsserts.objHasProperties(action, { type: ACTION.PLAY, target: game.state.hands[PLAYER.ALICE][0] });
@@ -831,7 +830,7 @@ describe('interpreting trash finesse', () => {
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][4]].status, CARD_STATUS.CM);
 	});
 
-	describe('recognizes real prompt over false trash finesse', async () => {
+	it('recognizes real prompt over false trash finesse', async () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx'],
 			['b1', 'g1', 'r5', 'r4'],
@@ -856,13 +855,13 @@ describe('interpreting trash finesse', () => {
 
 		takeTurn(game, 'Cathy plays r2', 'g5');
 
-		// After cathy doesn't play possible trash bluff, we are no longer chop moved and can infer regular connections.
+		// After Cathy doesn't play possible trash bluff, we are no longer chop moved and can infer regular connections.
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][1]], ['r3', 'y3', 'g3']);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]].status, undefined);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, undefined);
 	});
 
-	describe('interprets trash touch elimination on a 5', async () => {
+	it('interprets trash touch elimination on a 5', async () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['b1', 'g1', 'r1', 'y3', 'y4'],
@@ -880,6 +879,25 @@ describe('interpreting trash finesse', () => {
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].blind_playing, false);
 	});
 
+	it('interprets trash touch elimination on possible card in our hand', async () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g3', 'r2', 'y1', 'y4', 'g4'],
+			['b1', 'g1', 'r1', 'y3', 'y4'],
+		], {
+			level: { min: 14 },
+			play_stacks: [4, 2, 2, 0, 1],
+			starting: PLAYER.BOB,
+		});
+		takeTurn(game, 'Bob clues red to Cathy');
+		// Should be interpreted as a trash chop move.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][4]].status, CARD_STATUS.CM);
+
+		// No blind play expected as there is only one useful red card.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].blind_playing, false);
+	});
+
 	it(`shouldn't interpret playing a trash finesse if the card could already be blind playing`, async () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
@@ -891,7 +909,7 @@ describe('interpreting trash finesse', () => {
 			starting: PLAYER.BOB,
 		});
 		takeTurn(game, 'Bob clues 3 to Alice (slot 5)');
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].blind_playing, true);
+		assert(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].blind_playing);
 
 		takeTurn(game, 'Cathy clues 1 to Bob (slot 4)');
 		// Since Alice was already going to play, this cannot be a trash finesse and should instead be interpreted as a play.
@@ -979,7 +997,7 @@ describe('interpreting trash finesse', () => {
 
 		takeTurn(game, 'Bob clues red to Cathy');
 
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].trash, true);
+		assert(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].trash);
 
 		takeTurn(game, 'Cathy discards r1', 'p1');
 		takeTurn(game, 'Donald plays r4', 'g5');
@@ -1030,8 +1048,8 @@ describe('interpreting trash finesse', () => {
 		// Donald knows they have r5, so Alice should still recognize this as a trash finesse.
 		takeTurn(game, 'Donald clues red to Alice (slot 3)');
 
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing, true);
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]].trash, true);
+		assert(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing);
+		assert(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]].trash);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
 	});
 

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -1,7 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { COLOUR, PLAYER, preClue, setup, takeTurn } from '../test-utils.js';
+import { COLOUR, PLAYER, preClue, setup, takeTurn, VARIANTS } from '../test-utils.js';
 import * as ExAsserts from '../extra-asserts.js';
 import HGroup from '../../src/conventions/h-group.js';
 import { CARD_STATUS } from '../../src/basics/Card.js';
@@ -195,6 +195,22 @@ describe('interpreting trash push', () => {
 
 		// Alice's slot 4 should be finessed.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][1]].status, CARD_STATUS.FINESSED);
+	});
+
+	it('will interpret a receiving a trash push by colour in rainbow', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r4', 'g3', 'b5', 'b4', 'y3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [5, 0, 0, 0, 5],
+			starting: PLAYER.BOB,
+			variant: VARIANTS.RAINBOW,
+		});
+		takeTurn(game, 'Bob clues red to Alice (slot 5)');
+
+		// Alice's slot 4 should be finessed.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.FINESSED);
 	});
 
 	it('will interpret a receiving a trash push finesse', () => {

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -1,0 +1,303 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { PLAYER, setup, takeTurn } from '../test-utils.js';
+import * as ExAsserts from '../extra-asserts.js';
+import HGroup from '../../src/conventions/h-group.js';
+import { CARD_STATUS } from '../../src/basics/Card.js';
+
+import logger from '../../src/tools/logger.js';
+import { ACTION } from '../../src/constants.js';
+import { find_clues } from '../../src/conventions/h-group/clue-finder/clue-finder.js';
+import { determine_playable_card } from '../../src/conventions/h-group/action-helper.js';
+import { find_urgent_actions } from '../../src/conventions/h-group/urgent-actions.js';
+import { ACTION_PRIORITY } from '../../src/conventions/h-group/h-constants.js';
+
+logger.setLevel(logger.LEVELS.ERROR);
+
+describe('giving trash order chop move', () => {
+	it('will find a tocm to the next player', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r4', 'r4', 'g4', 'r3', 'r5']
+		], {
+			play_stacks: [1, 1, 1, 1, 1],
+			level: { min: 14 },
+			starting: PLAYER.BOB
+		});
+
+		// With all 1's already played, the clue saves the last 2 cards
+		// and gives Alice two trash cards.
+		takeTurn(game, 'Bob clues 1 to Alice (slots 2,3)');
+
+		const { state } = game;
+		const our_hand = state.ourHand;
+
+		const playable_priorities = determine_playable_card(game, game.me.thinksPlayables(state, PLAYER.ALICE));
+		const { play_clues, save_clues, fix_clues, stall_clues } = find_clues(game);
+		const urgent_actions = find_urgent_actions(game, play_clues, save_clues, fix_clues, stall_clues, playable_priorities);
+
+		// Alice can save the 5 by discarding out of order.
+		ExAsserts.objHasProperties(urgent_actions[ACTION_PRIORITY.ONLY_SAVE][0], { type: ACTION.DISCARD, target: our_hand[2] });
+	});
+
+	it('will find a tocm to cathy', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g3', 'r3', 'y3', 'y4', 'g4'],
+			['r4', 'r4', 'g4', 'r3', 'r5'],
+		], {
+			play_stacks: [0, 5, 0, 0, 0],
+			level: { min: 14 },
+			starting: PLAYER.BOB
+		});
+
+		// With all yellow's played, the clue saves slot 5,
+		// and gives Alice three trash cards.
+		takeTurn(game, 'Bob clues yellow to Alice (slots 2,3,4)');
+
+		const { state } = game;
+		const our_hand = state.hands[PLAYER.ALICE];
+
+		const playable_priorities = determine_playable_card(game, [our_hand[1], our_hand[2], our_hand[3]]);
+		const { play_clues, save_clues, fix_clues, stall_clues } = find_clues(game);
+		const urgent_actions = find_urgent_actions(game, play_clues, save_clues, fix_clues, stall_clues, playable_priorities);
+
+		ExAsserts.objHasProperties(urgent_actions[ACTION_PRIORITY.ONLY_SAVE + Object.keys(ACTION_PRIORITY).length][0], { type: ACTION.DISCARD, target: our_hand[3] });
+	});
+
+});
+
+describe('interpreting touch order chop move', () => {
+	it('will interpret a tocm to the next player', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['b4', 'b1', 'g1', 'r1', 'r5'],
+			['y4', 'r4', 'g4', 'r4', 'b5']
+		], {
+			level: { min: 14 },
+			play_stacks: [1, 1, 1, 1, 1],
+		});
+
+		takeTurn(game, 'Alice clues 1 to Bob');
+		takeTurn(game, 'Bob discards g1', 'r1');
+
+		// Cathy's slot 5 should be chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][4]].status, CARD_STATUS.CM);
+	});
+	it('will interpret a tocm skipping a player', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['b4', 'b1', 'g1', 'r1', 'r5'],
+			['y4', 'r4', 'g4', 'r4', 'b5']
+		], {
+			level: { min: 14 },
+			starting: PLAYER.ALICE,
+			play_stacks: [1, 1, 1, 1, 1],
+		});
+
+		takeTurn(game, 'Alice clues 1 to Bob');
+		takeTurn(game, 'Bob discards r1', 'r1');		// OCM on Alice
+
+		// Alice's slot 5 should be chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
+	});
+});
+
+describe('interpreting shout discard order chop move', () => {
+	it('will interpret a sdocm to the next player', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['b4', 'b1', 'g1', 'r1', 'r5'],
+			['y4', 'r4', 'g4', 'r4', 'b5']
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 1, 1, 1],
+		});
+		takeTurn(game, 'Alice clues 1 to Bob');
+		takeTurn(game, 'Bob discards b1', 'r1');
+
+		// Cathy's slot 5 should be chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][4]].status, CARD_STATUS.CM);
+	});
+
+	it('will interpret a sdocm to the player after next', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['b4', 'b1', 'g1', 'r1', 'r5'],
+			['y4', 'r4', 'g4', 'r4', 'b3']
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 1, 1, 1],
+		});
+		takeTurn(game, 'Alice clues 1 to Bob');
+		takeTurn(game, 'Bob discards g1', 'r1');
+
+		// Alice's slot 5 should be chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
+	});
+});
+
+describe('interpreting trash push', () => {
+	it('will interpret a trash push', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r2', 'r2', 'b1', 'g1', 'r1'],
+		], {
+			level: { min: 14 },
+			play_stacks: [1, 1, 1, 1, 1],
+		});
+		takeTurn(game, 'Alice clues 1 to Bob');
+
+		// Bob's slot 2 should be finessed.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][1]].status, CARD_STATUS.FINESSED);
+	});
+
+	it('will interpret a receiving a trash push', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r4', 'g3', 'b5', 'b4', 'y3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [5, 1, 3, 2, 1],
+			starting: PLAYER.BOB
+		});
+		takeTurn(game, 'Bob clues 1 to Alice (slots 3,4,5)');
+
+		// Bob's slot 4 should be finessed.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][1]].status, CARD_STATUS.FINESSED);
+	});
+});
+
+describe('interpreting trash finesse', () => {
+	it('will interpret a trash finesse', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['r1', 'p3', 'b4', 'g4'],
+			['y5', 'g2', 'g1', 'p2'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 2, 0, 0],
+		});
+		takeTurn(game, 'Alice clues 1 to Cathy');
+
+		// Bob's slot 1 should be blind played.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][0]].blind_playing, true);
+		// Cathy's slot 4 should be chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, CARD_STATUS.CM);
+	});
+
+	it('will interpret an ambiguous direct play', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['r1', 'p3', 'b4', 'g4'],
+			['y5', 'g2', 'b1', 'p2'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 2, 0, 0],
+		});
+		takeTurn(game, 'Alice clues 1 to Cathy');
+		takeTurn(game, 'Bob discards g4', 'p3');
+
+		// Cathy's slot 3 should be assumed playable.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.CATHY][2]], ['r1', 'b1', 'p1']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, undefined);
+	});
+
+	it('will interpret a reverse trash finesse', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['y5', 'g2', 'g1', 'p2'],
+			['r1', 'p3', 'b4', 'g4'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 2, 0, 0],
+		});
+		takeTurn(game, 'Alice clues 1 to Bob');
+
+		// Cathy's slot 1 should be finessed.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.FINESSED);
+		// Bob's slot 4 should be chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][3]].status, CARD_STATUS.CM);
+	});
+
+	it('will interpret receiving a trash finesse', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['y5', 'g2', 'g4', 'p2'],
+			['r1', 'p3', 'b4', 'g4'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 2, 0, 0],
+			starting: PLAYER.BOB,
+		});
+		takeTurn(game, 'Bob clues 1 to Alice (slot 3)');
+
+		// Cathy's slot 1 should be blind played.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.MAYBE_BLUFFED);
+		// Alice's slot 4 should be chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+	});
+
+	it('will interpret receiving an ambiguous direct play', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['y5', 'g2', 'g4', 'p2'],
+			['r1', 'p3', 'b4', 'g4'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 2, 0, 0],
+			starting: PLAYER.BOB,
+		});
+		takeTurn(game, 'Bob clues 1 to Alice (slot 3)');
+
+		// Cathy's slot 1 is expected to blind play.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.MAYBE_BLUFFED);
+		// Alice's slot 4 should be chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+
+		takeTurn(game, 'Cathy discards g4', 'p3');
+
+		// Alice's slot 3 should be assumed playable.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['r1', 'b1', 'p1']);
+		// Alice is not chop moved.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, undefined);
+	});
+
+	it('will interpret receiving a reverse trash finesse', async () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['r1', 'p3', 'b4', 'g4'],
+			['y5', 'g2', 'g4', 'p3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 2, 1, 1],
+			starting: PLAYER.CATHY,
+		});
+		// Alice can see that the identity of the promised play matches Bob's r1.
+		// She should treat it as a reverse trash finesse and chop move her slot 4.
+		takeTurn(game, 'Cathy clues 1 to Alice (slot 3)');
+
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['r1', 'y1', 'g1', 'b1', 'p1']);
+	});
+
+	it('will interpret receiving a play when a possible reverse trash finesse is visible', async () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['r1', 'p3', 'b4', 'g4'],
+			['y5', 'g2', 'g4', 'p3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 2, 0, 0],
+			starting: PLAYER.CATHY,
+		});
+		// This could be a trash finesse on the r1, however Alice can see
+		// there are other playable 1s and so should treat it as a straight play.
+		takeTurn(game, 'Cathy clues 1 to Alice (slot 3)');
+
+		// Alice's slot 3 should be assumed a playable 1.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['r1', 'b1', 'p1']);
+	});
+
+});

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -823,6 +823,23 @@ describe('interpreting trash finesse', () => {
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].status, undefined);
 	});
 
+	it(`plays into an ambiguous trash finesse`, async () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['y4', 'g1', 'r1', 'b3'],
+			['p4', 'p3', 'p5', 'p3'],
+			['b1', 'g5', 'r1', 'y1']
+		], {
+			level: { min: 14 },
+			play_stacks: [3, 3, 3, 0, 0],
+			starting: PLAYER.CATHY
+		});
+
+		takeTurn(game, 'Cathy clues 1 to Bob');
+		takeTurn(game, 'Donald discards y1', 'b4');
+
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].status, CARD_STATUS.FINESSED);
+	});
 });
 
 describe('giving trash finesses', () => {

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -756,6 +756,28 @@ describe('interpreting trash finesse', () => {
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][2]].status, CARD_STATUS.CM);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][3]].status, CARD_STATUS.CM);
 	});
+
+	it('will interpret receiving a direct play on a known good card', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['b3', 'p4', 'p2', 'b5'],
+			['y5', 'b4', 'r1', 'g2'],
+			['g1', 'b4', 'p1', 'g4']
+		], {
+			level: { min: 14 },
+			play_stacks: [5, 4, 5, 1, 4],
+			starting: PLAYER.BOB,
+			discarded: ['r2', 'y2']		// We can see all 2s except both copies of b2.
+		});
+		takeTurn(game, 'Bob clues 2 to Alice (slot 3)');
+
+		// Cathy is never trash finessed/bluffed here, but that isn't common knowledge.
+
+		takeTurn(game, 'Cathy discards g2', 'p3');
+
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['b2']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, undefined);
+	});
 });
 
 describe('giving trash finesses', () => {

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -193,8 +193,25 @@ describe('interpreting trash push', () => {
 		});
 		takeTurn(game, 'Bob clues 1 to Alice (slots 3,4,5)');
 
-		// Bob's slot 4 should be finessed.
+		// Alice's slot 4 should be finessed.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][1]].status, CARD_STATUS.FINESSED);
+	});
+
+	it('will interpret a receiving a trash push finesse', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['b4', 'g3', 'b5', 'r4', 'y1'],
+			['r2', 'g5', 'p5', 'p2', 'y3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [2, 1, 3, 2, 1],
+			starting: PLAYER.CATHY
+		});
+		takeTurn(game, 'Cathy clues 1 to Bob (slot 5)');
+
+		// Alice's slot 1 should be finessed as r3.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].status, CARD_STATUS.F_MAYBE_BLUFF);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]], ['r3']);
 	});
 });
 
@@ -635,7 +652,7 @@ describe('interpreting trash finesse', () => {
 
 		// Alice's slot 1 should be r1 blind playing.
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]], ['r1', 'y2', 'g2', 'b2', 'p2']);
-		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.BOB][3]], ['y1', 'g1', 'b1', 'p1']);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.BOB][3]], ['r1', 'y1', 'g1', 'b1', 'p1']);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].blind_playing, true);
 
 		// Bob's slots 5 is chop moved.

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -716,6 +716,29 @@ describe('interpreting trash finesse', () => {
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.BOB][3]], ['y1', 'g1', 'p1', 'r1']);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][4]].status, undefined);
 	});
+
+	it(`should recognize own trash finesse where necessary to connect before target`, async () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx'],
+			['b3', 'b4', 'p5', 'r5'],
+			['r2', 'p2', 'p1', 'y3'],
+			['r1', 'y2', 'y5', 'r3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 3, 4, 4, 3],
+			starting: PLAYER.BOB,
+		});
+		// r1 -> r2 -> r3
+		takeTurn(game, 'Bob clues 3 to Donald');
+
+		// Trash finesse on b4.
+		takeTurn(game, 'Cathy clues 4 to Bob');
+
+		// Since Alice was already going to play, this cannot be an r4 trash finesse and should instead be interpreted as an immediate y4, p4.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]], ['y4', 'p4']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][2]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][3]].status, CARD_STATUS.CM);
+	});
 });
 
 describe('giving trash finesses', () => {

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -66,6 +66,52 @@ describe('giving trash order chop move', () => {
 		ExAsserts.objHasProperties(urgent_actions[ACTION_PRIORITY.ONLY_SAVE + Object.keys(ACTION_PRIORITY).length][0], { type: ACTION.DISCARD, target: our_hand[3] });
 	});
 
+	it(`doesn't do a bad sdcm`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g3', 'r3', 'y3', 'y4', 'y1'],
+			['r4', 'r4', 'g4', 'r3', 'r5']
+		], {
+			play_stacks: [1, 1, 1, 1, 1],
+			level: { min: 14 },
+			clue_tokens: 1,
+			starting: PLAYER.CATHY
+		});
+
+		takeTurn(game, 'Cathy clues 1 to Alice (slots 3,4)');
+
+		const { state } = game;
+		const our_hand = state.hands[PLAYER.ALICE];
+		const playable_priorities = determine_playable_card(game, [our_hand[1], our_hand[2], our_hand[3]]);
+		const { play_clues, save_clues, fix_clues, stall_clues } = find_clues(game);
+		const urgent_actions = find_urgent_actions(game, play_clues, save_clues, fix_clues, stall_clues, playable_priorities);
+		// Alice tries discarding slot 2 to save Cathy's r5, even though this is both illegal and game-risking.
+		assert.equal(urgent_actions[ACTION_PRIORITY.ONLY_SAVE + Object.keys(ACTION_PRIORITY).length].length, 0);
+	});
+
+	it(`can still discard chop as a scream to the next player`, () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['g3', 'r3', 'y3', 'y4', 'r5'],
+			['r4', 'r4', 'g4', 'r3', 'y1']
+		], {
+			play_stacks: [1, 1, 1, 1, 1],
+			level: { min: 14 },
+			clue_tokens: 1,
+			starting: PLAYER.CATHY
+		});
+
+		takeTurn(game, 'Cathy clues 1 to Alice (slot 4)');
+
+		const { state } = game;
+		const our_hand = state.hands[PLAYER.ALICE];
+		const playable_priorities = determine_playable_card(game, [our_hand[1], our_hand[2], our_hand[3]]);
+		const { play_clues, save_clues, fix_clues, stall_clues } = find_clues(game);
+		const urgent_actions = find_urgent_actions(game, play_clues, save_clues, fix_clues, stall_clues, playable_priorities);
+		// Alice has known trash, but should signal to Bob that he cannot discard his chop.
+		ExAsserts.objHasProperties(urgent_actions[ACTION_PRIORITY.ONLY_SAVE][0], { type: ACTION.DISCARD, target: our_hand[2] });
+	});
+
 });
 
 describe('interpreting trash order chop move', () => {

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -698,7 +698,7 @@ describe('interpreting trash finesse', () => {
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].blind_playing, false);
 	});
 
-	it(`shouldn't interpret a trash finesse if the card could already be blind playing`, async () => {
+	it(`shouldn't interpret playing a trash finesse if the card could already be blind playing`, async () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['g2', 'g5', 'g3', 'y1', 'p3'],

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -739,7 +739,7 @@ describe('interpreting trash finesse', () => {
 			['xx', 'xx', 'xx', 'xx'],
 			['b3', 'b4', 'p5', 'r5'],
 			['r2', 'p2', 'p1', 'y3'],
-			['r1', 'y2', 'y5', 'r3'],
+			['r1', 'y4', 'y5', 'r3'],
 		], {
 			level: { min: 14 },
 			play_stacks: [0, 3, 4, 4, 3],

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -213,12 +213,16 @@ describe('interpreting trash finesse', () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['r1', 'p3', 'b4', 'g4', 'g1'],
-			['y1', 'g2', 'y5', 'p2', 'b3'],
+			['y1', 'g2', 'b3', 'p3', 'y5'],
 		], {
 			level: { min: 14 },
-			play_stacks: [0, 1, 4, 0, 0],
+			play_stacks: [0, 1, 3, 0, 0],
+			starting: PLAYER.BOB,
 		});
-		// The clue looks like Alice is telling Cathy to play g5.
+		takeTurn(game, 'Bob clues 5 to Cathy');
+		takeTurn(game, 'Cathy clues 5 to Alice (slot 5)');
+
+		// The clue looks like Alice is telling Cathy to play g4.
 		// If Bob plays slot 1, it will prove that Alice's clued card was in fact trash, and
 		// saves several useful cards in cathy's hand.
 		takeTurn(game, 'Alice clues green to Cathy');
@@ -250,6 +254,27 @@ describe('interpreting trash finesse', () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
 			['r1', 'p3', 'b4', 'g4', 'g1'],
+			['y5', 'g4', 'b1', 'p2', 'b3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 3, 0, 0],
+			starting: PLAYER.BOB,
+		});
+		takeTurn(game, 'Bob clues 5 to Cathy');
+		takeTurn(game, 'Cathy clues 5 to Alice (slot 5)');
+
+		takeTurn(game, 'Alice clues green to Cathy');
+		takeTurn(game, 'Bob discards g1', 'p3');
+
+		// Cathy's slot 2 should be assumed playable.
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.CATHY][1]], ['g4']);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, undefined);
+	});
+
+	it('will interpret a colour 5 direct play', () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r1', 'p3', 'b4', 'g4', 'g1'],
 			['y5', 'g5', 'b1', 'p2', 'b3'],
 		], {
 			level: { min: 14 },
@@ -260,7 +285,6 @@ describe('interpreting trash finesse', () => {
 
 		// Cathy's slot 2 should be assumed playable.
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.CATHY][1]], ['g5']);
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][3]].status, undefined);
 	});
 
 	it('will interpret a reverse rank trash finesse', () => {
@@ -284,19 +308,20 @@ describe('interpreting trash finesse', () => {
 	it('will interpret a reverse colour trash finesse', () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
-			['y5', 'b1', 'g2', 'p2', 'b3'],
-			['g5', 'p3', 'b4', 'g4', 'g1'],
+			['y5', 'b1', 'g2', 'p2', 'b5'],
+			['g4', 'p3', 'b4', 'g4', 'g1'],
 		], {
 			level: { min: 14 },
-			play_stacks: [0, 1, 4, 1, 1],
+			play_stacks: [0, 1, 3, 1, 1],
+			starting: PLAYER.CATHY,
 		});
+		takeTurn(game, 'Cathy clues 5 to Bob');
 		takeTurn(game, 'Alice clues green to Bob');
 
 		// Cathy's slot 1 should be finessed.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.FINESSED);
-		// Bob's slots 4 and 5 should be chop moved.
+		// Bob's slots 4 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][3]].status, CARD_STATUS.CM);
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][4]].status, CARD_STATUS.CM);
 	});
 
 	it('will interpret receiving a rank trash finesse', () => {
@@ -342,73 +367,74 @@ describe('interpreting trash finesse', () => {
 	it('will interpret receiving a colour trash finesse', () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
-			['y5', 'g2', 'p4', 'p2', 'g1'],
-			['g5', 'p3', 'b4', 'g4', 'b3'],
+			['y5', 'g2', 'p4', 'p2', 'r1'],
+			['g4', 'p3', 'b4', 'g4', 'b3'],
 		], {
 			level: { min: 14 },
-			play_stacks: [0, 1, 4, 0, 0],
-			starting: PLAYER.BOB,
+			play_stacks: [0, 1, 3, 0, 0],
+			starting: PLAYER.CATHY,
 		});
+		takeTurn(game, 'Cathy clues 5 to Alice (slot 5)');
+		takeTurn(game, 'Alice clues 1 to Bob');
 		takeTurn(game, 'Bob clues green to Alice (slot 3)');
 
 		// Cathy's slot 1 should be blind played.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.FINESSED);
-		// Alice's slots 4 and 5 should be chop moved.
+		// Alice's slot 4 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
 	});
 
 	it('will interpret receiving a colour trash bluff', () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
-			['y5', 'g2', 'p4', 'p2', 'g1'],
+			['y5', 'g2', 'p4', 'p2', 'p1'],
 			['r1', 'p3', 'b4', 'g4', 'b3'],
 		], {
 			level: { min: 14 },
-			play_stacks: [0, 1, 4, 0, 0],
-			starting: PLAYER.BOB,
+			play_stacks: [0, 1, 3, 0, 0],
+			starting: PLAYER.CATHY,
 		});
+		takeTurn(game, 'Cathy clues 5 to Alice (slot 5)');
+		takeTurn(game, 'Alice clues purple to Bob');
 		takeTurn(game, 'Bob clues green to Alice (slot 3)');
 
 		// Cathy's slot 1 should be blind played.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.MAYBE_BLUFFED);
-		// Alice's slots 4 and 5 should be chop moved.
+		// Alice's slot 4 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
 
 		takeTurn(game, 'Cathy plays r1', 'b5');
 
 		// Alice's slot 2 must be known trash.
-		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['g1', 'g2', 'g3', 'g4']);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['g1', 'g2', 'g3']);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
 	});
 
 	it(`will interpret receiving a colour play when possible trash bluff isn't played`, () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx', 'xx'],
-			['y5', 'g2', 'p4', 'p2', 'g1'],
-			['r1', 'b3', 'p1', 'g4', 'b3'],
+			['y5', 'g2', 'p4', 'p2', 'p1'],
+			['r1', 'p3', 'b4', 'g4', 'b3'],
 		], {
 			level: { min: 14 },
-			play_stacks: [0, 1, 4, 0, 0],
-			starting: PLAYER.BOB,
+			play_stacks: [0, 1, 3, 0, 0],
+			starting: PLAYER.CATHY,
 		});
+		takeTurn(game, 'Cathy clues 5 to Alice (slot 5)');
+		takeTurn(game, 'Alice clues purple to Bob');
 		takeTurn(game, 'Bob clues green to Alice (slot 3)');
 
 		// Cathy's slot 1 should be blind played.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].status, CARD_STATUS.MAYBE_BLUFFED);
-		// Alice's slots 4 and 5 should be chop moved.
+		// Alice's slot 4 should be chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, CARD_STATUS.CM);
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, CARD_STATUS.CM);
 
 		takeTurn(game, 'Cathy discards b3 (slot 5)', 'p5');
 
 		// Alice has a direct play.
-		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['g5']);
+		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]], ['g4']);
 		// Alice's is no longer chop moved.
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, undefined);
-		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][4]].status, undefined);
 	});
 
 	it('will interpret receiving an ambiguous rank direct play', () => {
@@ -624,6 +650,24 @@ describe('interpreting trash finesse', () => {
 		ExAsserts.cardHasInferences(game.common.thoughts[game.state.hands[PLAYER.ALICE][1]], ['r3', 'y3', 'g3']);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][2]].status, undefined);
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][3]].status, undefined);
+	});
+
+	describe('interprets trash touch elimination on a 5', async () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['b1', 'g1', 'r1', 'y3', 'y4'],
+			['g3', 'r2', 'y1', 'r5', 'g4'],
+		], {
+			level: { min: 14 },
+			play_stacks: [4, 2, 2, 0, 1],
+		});
+		takeTurn(game, 'Alice clues red to Bob');
+		// Should be interpreted as a trash chop move.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][3]].status, CARD_STATUS.CM);
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.BOB][4]].status, CARD_STATUS.CM);
+
+		// No blind play expected as there is only one useful red card.
+		assert.equal(game.common.thoughts[game.state.hands[PLAYER.CATHY][0]].blind_playing, false);
 	});
 });
 

--- a/test/h-group/level-14.js
+++ b/test/h-group/level-14.js
@@ -960,20 +960,6 @@ describe('interpreting trash finesse', () => {
 		assert.equal(game.common.thoughts[game.state.hands[PLAYER.ALICE][0]].status, CARD_STATUS.FINESSED);
 	});
 
-	it(`won't chop move trash`, async () => {
-		const game = setup(HGroup, [
-			['xx', 'xx', 'xx', 'xx', 'xx'],
-			['p2', 'p2', 'g1', 'r1', 'r1'],
-			['p4', 'y5', 'b4', 'r2', 'y1']
-		], {
-			level: { min: 14 },
-			play_stacks: [3, 3, 3, 3, 1]
-		});
-
-		const { play_clues } = find_clues(game);
-		assert.ok(!play_clues[PLAYER.CATHY].some(clue => clue.type === CLUE.RANK && clue.value === 2));
-	});
-
 	it(`understands a trash finesse where giver knows they have the last id`, async () => {
 		const game = setup(HGroup, [
 			['xx', 'xx', 'xx', 'xx'],
@@ -1017,5 +1003,38 @@ describe('giving trash finesses', () => {
 		const { play_clues } = find_clues(game);
 		// Red to Cathy is not a valid clue as Cathy will think it is r5.
 		assert.ok(!play_clues[PLAYER.CATHY].some(clue => clue.type === CLUE.COLOUR && clue.value === COLOUR.RED));
+	});
+
+	it(`won't chop move trash`, async () => {
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['p2', 'p2', 'g1', 'r1', 'r1'],
+			['p4', 'y5', 'b4', 'r2', 'y1']
+		], {
+			level: { min: 14 },
+			play_stacks: [3, 3, 3, 3, 1]
+		});
+
+		const { play_clues } = find_clues(game);
+		assert.ok(!play_clues[PLAYER.CATHY].some(clue => clue.type === CLUE.RANK && clue.value === 2));
+	});
+
+	it(`won't give a trash finesse starting with target`, () => {
+		// Based on https://hanab.live/replay/1797812#29
+		const game = setup(HGroup, [
+			['xx', 'xx', 'xx', 'xx', 'xx'],
+			['r1', 'b4', 'y4', 'b2', 'y2'],
+			['r2', 'g4', 'g5', 'p2', 'p3'],
+		], {
+			level: { min: 14 },
+			play_stacks: [0, 1, 2, 2, 2],
+			starting: PLAYER.CATHY
+		});
+		// Bob knows about his 2's
+		takeTurn(game, 'Cathy clues 2 to Bob');
+
+		// Alice should not clue 2 to Bob - cluing an already clued card is not a trash push.
+		const { play_clues } = find_clues(game);
+		assert.ok(!play_clues[PLAYER.BOB].some(clue => clue.type === CLUE.RANK && clue.value === 2));
 	});
 });

--- a/test/h-group/level-3.js
+++ b/test/h-group/level-3.js
@@ -93,7 +93,7 @@ describe('playing 1s in the correct order', () => {
 
 		const clue = { type: CLUE.RANK, value: 1 };
 		const list = game.state.clueTouched(game.state.hands[PLAYER.CATHY], clue);
-		const { focus } = determine_focus(game, game.state.hands[PLAYER.CATHY], game.common, list, clue);
+		const { focus } = determine_focus(game, game.state.hands[PLAYER.CATHY], game.common, list, PLAYER.BOB, PLAYER.CATHY, clue);
 
 		// The focus of the clue is Cathy's slot 4.
 		assert.equal(focus, game.state.hands[PLAYER.CATHY][3]);


### PR DESCRIPTION
Add support for level 14 conventions:
* Trash order chop move (TOCM)
* Shout discard order chop move (SDOCM)
* Trash pushes (required playable by target)
* Rank trash finesses, trash bluffs, and reverse trash finesses
* Colour trash finesses, trash bluffs, and reverse trash finesses
* Ensures that all newly touched cards in a trash finesse / bluff are known trash.
* Only finesse when there are multiple possible trash identities. If only one should be treated as trash touch elimination [level 18](https://hanabi.github.io/level-18#interaction-between-trash-touch-elimination--potentially-unknown-trash).

Future:
* Ensure priority discard on known reverse finesse?
* Find trash finesses that connect earlier than standard connections.